### PR TITLE
feat: Set up Dependabot for npm, GitHub Actions, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+version: 2
+updates:
+  # Enable version updates for npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "whispr-team"  
+    assignees:
+      - "glopez-dev"   # Remplacez par votre nom d'utilisateur
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+    # Grouper les mises à jour mineures et patches ensemble
+    groups:
+      nestjs:
+        patterns:
+          - "@nestjs/*"
+        update-types:
+          - "minor"
+          - "patch"
+      types:
+        patterns:
+          - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    # Ignorer certaines dépendances si nécessaire
+    ignore:
+      # Exemple: ignorer les mises à jour majeures pour certains packages critiques
+      - dependency-name: "typeorm"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "grpc-tools"
+        update-types: ["version-update:semver-major"]
+    # Permettre les mises à jour de vulnérabilités même si ignorées
+    allow:
+      - dependency-type: "all"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "github-actions"
+      - "ci/cd"
+
+  # Enable version updates for Docker (si vous avez un Dockerfile)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "docker"
+    labels:
+      - "docker"
+      - "dependencies"


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration file to automate dependency updates for npm packages, GitHub Actions, and Docker. The configuration schedules weekly checks, groups updates for related dependencies, and customizes reviewer, assignee, and label settings to streamline dependency management.

Dependency update automation:

* Added `.github/dependabot.yml` to enable and configure Dependabot for npm, GitHub Actions, and Docker dependencies, including scheduling, grouping, reviewer/assignee assignment, commit message formatting, and labeling.
* Configured rules to group minor and patch updates for `@nestjs/*`, `@types/*`, and development dependencies, while ignoring major updates for critical packages like `typeorm` and `grpc-tools`.
* Set up separate schedules and limits for npm, GitHub Actions, and Docker, all running weekly on Mondays at 09:00 Europe/Paris time.
