### PR TITLE
[WHISPR-102] Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,7 +66,7 @@ updates:
       - "github-actions"
       - "ci/cd"
 
-  # Enable version updates for Docker (si vous avez un Dockerfile)
+  # Enable version updates for Docker (if you have a Dockerfile)
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+version: 2
+updates:
+  # Enable version updates for npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "whispr-team"  
+    assignees:
+      - "glopez-dev"   # Remplacez par votre nom d'utilisateur
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+    # Grouper les mises à jour mineures et patches ensemble
+    groups:
+      nestjs:
+        patterns:
+          - "@nestjs/*"
+        update-types:
+          - "minor"
+          - "patch"
+      types:
+        patterns:
+          - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    # Ignorer certaines dépendances si nécessaire
+    ignore:
+      # Exemple: ignorer les mises à jour majeures pour certains packages critiques
+      - dependency-name: "typeorm"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "grpc-tools"
+        update-types: ["version-update:semver-major"]
+    # Permettre les mises à jour de vulnérabilités même si ignorées
+    allow:
+      - dependency-type: "all"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "github-actions"
+      - "ci/cd"
+
+  # Enable version updates for Docker (si vous avez un Dockerfile)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "docker"
+    labels:
+      - "docker"
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     reviewers:
       - "whispr-team"
     assignees:
-      - "glopez-dev" # Remplacez par votre nom d'utilisateur
+      - "glopez-dev" # Replace with your username
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     reviewers:
       - "whispr-team"
     assignees:
-      - "glopez-dev"   # Remplacez par votre nom d'utilisateur
+      - "glopez-dev" # Remplacez par votre nom d'utilisateur
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       timezone: "Europe/Paris"
     open-pull-requests-limit: 10
     reviewers:
-      - "whispr-team"  
+      - "whispr-team"
     assignees:
       - "glopez-dev"   # Remplacez par votre nom d'utilisateur
     commit-message:


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration file to automate dependency updates for npm, GitHub Actions, and Docker. The configuration schedules weekly checks, customizes update grouping and labeling, and sets rules for reviewers, assignees, and commit message formatting.

Dependency update automation:

* Added a Dependabot configuration to enable and schedule automated updates for npm dependencies, GitHub Actions workflows, and Dockerfiles, with weekly checks set for Monday at 09:00 (Europe/Paris timezone).
* Configured rules for grouping updates (e.g., grouping NestJS and types packages, grouping dev dependencies), limiting open pull requests, and customizing commit message prefixes and labels for each ecosystem.
* Set up reviewers and assignees for npm updates, and specified exceptions to ignore major updates for critical packages like `typeorm` and `grpc-tools`, while still allowing vulnerability updates.