### PR TITLE
[WHISPR-122] Fix SonarQube workflow secrets configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,10 +98,20 @@ jobs:
           REDIS_URL: redis://localhost:6379
 
       ####################################################################################################
-      # SonarQube Analysis (conditional on should_deploy)
+      # SonarQube Analysis (conditional on should_deploy and secrets availability)
       ####################################################################################################
+      - name: Check SonarQube secrets
+        id: check-secrets
+        run: |
+          if [[ -n "${{ secrets.SONAR_TOKEN }}" && -n "${{ secrets.SONAR_HOST_URL }}" ]]; then
+            echo "secrets-available=true" >> $GITHUB_OUTPUT
+          else
+            echo "secrets-available=false" >> $GITHUB_OUTPUT
+            echo "⚠️ SonarQube secrets not configured. Skipping SonarQube analysis."
+          fi
+
       - name: SonarQube Analysis
-        if: ${{ inputs.should_deploy == 'true' }}
+        if: ${{ inputs.should_deploy == 'true' && steps.check-secrets.outputs.secrets-available == 'true' }}
         uses: sonarsource/sonarqube-scan-action@v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -109,7 +119,7 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: SonarQube Quality Gate
-        if: ${{ inputs.should_deploy == 'true' }}
+        if: ${{ inputs.should_deploy == 'true' && steps.check-secrets.outputs.secrets-available == 'true' }}
         uses: sonarsource/sonarqube-quality-gate-action@v1.1.0
         timeout-minutes: 5
         env:


### PR DESCRIPTION
## 🔧 Description

This PR fixes the SonarQube analysis workflow that was failing due to missing secrets configuration.

## 📋 Changes Made

- **Added secrets verification step** before SonarQube analysis
- **Made SonarQube steps conditional** on secrets availability (`SONAR_TOKEN` and `SONAR_HOST_URL`)
- **Added informative warning** when SonarQube secrets are not configured
- **Prevents workflow failures** when SonarQube is not yet set up

## 🔍 Technical Details

The workflow now includes a `check-secrets` step that:
1. Verifies if `SONAR_TOKEN` and `SONAR_HOST_URL` secrets are configured
2. Sets an output variable `secrets-available` 
3. SonarQube analysis only runs when both secrets are available AND `should_deploy` is true
4. Displays a warning message when secrets are missing instead of failing

## ✅ Benefits

- ✅ CI/CD pipeline won't fail when SonarQube secrets aren't configured yet
- ✅ Workflow remains backward compatible 
- ✅ Clear messaging when SonarQube is skipped
- ✅ Ready for SonarQube integration once secrets are added

## 🧪 Testing

- Workflow should pass without SonarQube secrets configured
- When secrets are added, SonarQube analysis will automatically run
- All other CI steps (tests, linting, formatting) continue to work normally

## 📚 Related

Resolves the SonarQube workflow issue identified in WHISPR-122