### PR TITLE
[WHISPR-125] Fix Docker SBOM workflow file path issue

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -161,6 +161,9 @@ jobs:
       - name: Verify SBOM file exists
         run: |
           echo "🔍 Checking SBOM outputs..."
+          # Check both possible outputs from anchore/sbom-action as a fallback strategy:
+          # - sbom-path: traditional output that may be unreliable in some versions
+          # - sbom-file: alternative output that might be set instead
           echo "SBOM path from action: '${{ steps.sbom.outputs.sbom-path }}'"
           echo "SBOM file from action: '${{ steps.sbom.outputs.sbom-file }}'"
           if [ -f "sbom.spdx.json" ]; then
@@ -171,7 +174,8 @@ jobs:
             echo "sbom_file_path=${{ steps.sbom.outputs.sbom-path }}" >> $GITHUB_OUTPUT
           else
             echo "❌ SBOM file not found!"
-            ls -la
+            # List only SBOM-related files for focused debugging
+            ls -la *.spdx.json || find . -name '*.spdx.json' || echo "No SBOM files found"
             exit 1
           fi
         id: verify-sbom

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -156,6 +156,25 @@ jobs:
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}
           format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Verify SBOM file exists
+        run: |
+          echo "🔍 Checking SBOM outputs..."
+          echo "SBOM path from action: '${{ steps.sbom.outputs.sbom-path }}'"
+          echo "SBOM file from action: '${{ steps.sbom.outputs.sbom-file }}'"
+          if [ -f "sbom.spdx.json" ]; then
+            echo "✅ SBOM file exists: sbom.spdx.json"
+            echo "sbom_file_path=sbom.spdx.json" >> $GITHUB_OUTPUT
+          elif [ -n "${{ steps.sbom.outputs.sbom-path }}" ] && [ -f "${{ steps.sbom.outputs.sbom-path }}" ]; then
+            echo "✅ SBOM file exists at: ${{ steps.sbom.outputs.sbom-path }}"
+            echo "sbom_file_path=${{ steps.sbom.outputs.sbom-path }}" >> $GITHUB_OUTPUT
+          else
+            echo "❌ SBOM file not found!"
+            ls -la
+            exit 1
+          fi
+        id: verify-sbom
 
       - name: Attest SBOM to image
         uses: actions/attest-sbom@v1
@@ -163,7 +182,7 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          sbom-path: ${{ steps.sbom.outputs.sbom-path }}
+          sbom-path: ${{ steps.verify-sbom.outputs.sbom_file_path }}
           push-to-registry: true
 
       - name: Generate provenance attestation


### PR DESCRIPTION
## 🐛 Problem
The Docker workflow was failing with `ENOENT: no such file or directory, open ''` error during SBOM attestation. This happened because the `anchore/sbom-action` wasn't reliably setting the `sbom-path` output, causing the subsequent `actions/attest-sbom` step to receive an empty file path.

## 🔧 Solution
- **Added explicit output file**: Set `output-file: sbom.spdx.json` to ensure predictable SBOM file naming
- **Added verification step**: Created a dedicated step to verify SBOM file exists and set reliable output
- **Enhanced error handling**: Added debugging logs and fallback logic for file path resolution
- **Improved reliability**: Use verified file path instead of potentially empty action output

## 🧪 Testing
- [x] Workflow syntax validation
- [x] File path verification logic
- [x] Error handling for missing files

## 📋 Changes
- Modified `.github/workflows/docker.yml`:
  - Added `output-file` parameter to SBOM generation
  - Added verification step with debugging output
  - Updated attestation step to use verified file path

## 🔗 Related
Fixes the SBOM workflow issue identified in Docker container registry pipeline.

---
**Branch**: `WHISPR-125-fix-docker-sbom-workflow`  
**Commit**: 🐛 fix(ci): resolve SBOM file path issue in Docker workflow