### PR TITLE
fix(phone-verification): reduce post-confirm verificationId TTL to 60 seconds

### DIFF
--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
@@ -158,7 +158,7 @@ describe('PhoneVerificationService', () => {
 			expect(result).toEqual({ verified: true });
 		});
 
-		it('should update verificationId with a 60-second TTL after confirm', async () => {
+		it('should update verificationId with a 60-second TTL after confirm when remaining TTL > 60s', async () => {
 			const verificationData: VerificationCode = {
 				phoneNumber: '+33612345678',
 				hashedCode: 'hashed-123456',
@@ -180,6 +180,49 @@ describe('PhoneVerificationService', () => {
 				expect.objectContaining({ verified: true }),
 				60 * 1000
 			);
+		});
+
+		it('should use remaining TTL when it is less than 60 seconds', async () => {
+			const verificationData: VerificationCode = {
+				phoneNumber: '+33612345678',
+				hashedCode: 'hashed-123456',
+				purpose: 'registration',
+				attempts: 0,
+				expiresAt: Date.now() + 30000, // 30 seconds remaining
+			};
+			mockVerificationRepo.findById.mockResolvedValue(verificationData);
+			mockCodeGenerator.compareCode.mockResolvedValue(true);
+			mockVerificationRepo.update.mockResolvedValue(undefined);
+
+			await service.confirmRegistrationVerification({
+				verificationId: 'verification-id',
+				code: '123456',
+			});
+
+			const [, , ttl] = mockVerificationRepo.update.mock.calls[0];
+			expect(ttl).toBeLessThanOrEqual(30000);
+			expect(ttl).toBeGreaterThan(0);
+		});
+
+		it('should delete verificationId instead of updating when already expired', async () => {
+			const verificationData: VerificationCode = {
+				phoneNumber: '+33612345678',
+				hashedCode: 'hashed-123456',
+				purpose: 'registration',
+				attempts: 0,
+				expiresAt: Date.now() - 1000, // already expired
+			};
+			mockVerificationRepo.findById.mockResolvedValue(verificationData);
+			mockCodeGenerator.compareCode.mockResolvedValue(true);
+			mockVerificationRepo.delete.mockResolvedValue(undefined);
+
+			await service.confirmRegistrationVerification({
+				verificationId: 'verification-id',
+				code: '123456',
+			});
+
+			expect(mockVerificationRepo.delete).toHaveBeenCalledWith('verification-id');
+			expect(mockVerificationRepo.update).not.toHaveBeenCalled();
 		});
 
 		it('should throw BadRequestException when verification not found', async () => {
@@ -239,7 +282,7 @@ describe('PhoneVerificationService', () => {
 			expect(result).toEqual({ verified: true, requires2FA: false });
 		});
 
-		it('should update verificationId with a 60-second TTL after confirm', async () => {
+		it('should update verificationId with a 60-second TTL after confirm when remaining TTL > 60s', async () => {
 			const verificationData: VerificationCode = {
 				phoneNumber: '+33612345678',
 				hashedCode: 'hashed-123456',

--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
@@ -204,7 +204,7 @@ describe('PhoneVerificationService', () => {
 			expect(ttl).toBeGreaterThan(0);
 		});
 
-		it('should delete verificationId instead of updating when already expired', async () => {
+		it('should delete verificationId and throw BadRequestException when already expired at confirm time', async () => {
 			const verificationData: VerificationCode = {
 				phoneNumber: '+33612345678',
 				hashedCode: 'hashed-123456',
@@ -216,10 +216,12 @@ describe('PhoneVerificationService', () => {
 			mockCodeGenerator.compareCode.mockResolvedValue(true);
 			mockVerificationRepo.delete.mockResolvedValue(undefined);
 
-			await service.confirmRegistrationVerification({
-				verificationId: 'verification-id',
-				code: '123456',
-			});
+			await expect(
+				service.confirmRegistrationVerification({
+					verificationId: 'verification-id',
+					code: '123456',
+				})
+			).rejects.toThrow(BadRequestException);
 
 			expect(mockVerificationRepo.delete).toHaveBeenCalledWith('verification-id');
 			expect(mockVerificationRepo.update).not.toHaveBeenCalled();

--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
@@ -158,6 +158,30 @@ describe('PhoneVerificationService', () => {
 			expect(result).toEqual({ verified: true });
 		});
 
+		it('should update verificationId with a 60-second TTL after confirm', async () => {
+			const verificationData: VerificationCode = {
+				phoneNumber: '+33612345678',
+				hashedCode: 'hashed-123456',
+				purpose: 'registration',
+				attempts: 0,
+				expiresAt: Date.now() + 900000,
+			};
+			mockVerificationRepo.findById.mockResolvedValue(verificationData);
+			mockCodeGenerator.compareCode.mockResolvedValue(true);
+			mockVerificationRepo.update.mockResolvedValue(undefined);
+
+			await service.confirmRegistrationVerification({
+				verificationId: 'verification-id',
+				code: '123456',
+			});
+
+			expect(mockVerificationRepo.update).toHaveBeenCalledWith(
+				'verification-id',
+				expect.objectContaining({ verified: true }),
+				60 * 1000
+			);
+		});
+
 		it('should throw BadRequestException when verification not found', async () => {
 			mockVerificationRepo.findById.mockResolvedValue(null);
 
@@ -213,6 +237,34 @@ describe('PhoneVerificationService', () => {
 			});
 
 			expect(result).toEqual({ verified: true, requires2FA: false });
+		});
+
+		it('should update verificationId with a 60-second TTL after confirm', async () => {
+			const verificationData: VerificationCode = {
+				phoneNumber: '+33612345678',
+				hashedCode: 'hashed-123456',
+				purpose: 'login',
+				attempts: 0,
+				expiresAt: Date.now() + 900000,
+			};
+			mockVerificationRepo.findById.mockResolvedValue(verificationData);
+			mockCodeGenerator.compareCode.mockResolvedValue(true);
+			mockVerificationRepo.update.mockResolvedValue(undefined);
+			mockUserAuthService.findByPhoneNumber.mockResolvedValue({
+				id: 'user-id',
+				twoFactorEnabled: false,
+			});
+
+			await service.confirmLoginVerification({
+				verificationId: 'verification-id',
+				code: '123456',
+			});
+
+			expect(mockVerificationRepo.update).toHaveBeenCalledWith(
+				'verification-id',
+				expect.objectContaining({ verified: true }),
+				60 * 1000
+			);
 		});
 
 		it('should return requires2FA: true when 2FA is enabled', async () => {

--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
@@ -239,7 +239,7 @@ export class PhoneVerificationService {
 		const remainingMs = verificationData.expiresAt - Date.now();
 		if (remainingMs <= 0) {
 			await this.verificationRepo.delete(verificationId);
-			return;
+			throw new BadRequestException('Invalid or expired verification code');
 		}
 		verificationData.verified = true;
 		await this.verificationRepo.update(

--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
@@ -35,6 +35,7 @@ export class PhoneVerificationService {
 	private readonly isDemoMode: boolean;
 	private readonly otpBypassCode: string | undefined;
 	private readonly VERIFICATION_TTL = 15 * 60; // 15 minutes in seconds
+	private readonly POST_CONFIRM_TTL = 60 * 1000; // 60 seconds post-confirm in milliseconds
 	private readonly MAX_ATTEMPTS = 5;
 	private readonly RATE_LIMIT_TTL = 60 * 60; // 1 hour in seconds
 	private readonly MAX_REQUESTS_PER_HOUR = 5;
@@ -236,11 +237,7 @@ export class PhoneVerificationService {
 		verificationData: VerificationCode
 	): Promise<void> {
 		verificationData.verified = true;
-		await this.verificationRepo.update(
-			verificationId,
-			verificationData,
-			Math.ceil(verificationData.expiresAt - Date.now())
-		);
+		await this.verificationRepo.update(verificationId, verificationData, this.POST_CONFIRM_TTL);
 	}
 
 	/**

--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
@@ -34,10 +34,10 @@ export class PhoneVerificationService {
 	private readonly logger = new Logger(PhoneVerificationService.name);
 	private readonly isDemoMode: boolean;
 	private readonly otpBypassCode: string | undefined;
-	private readonly VERIFICATION_TTL = 15 * 60; // 15 minutes in seconds
-	private readonly POST_CONFIRM_TTL = 60 * 1000; // 60 seconds post-confirm in milliseconds
+	private readonly VERIFICATION_TTL_MS = 15 * 60 * 1000; // 15 minutes in milliseconds
+	private readonly POST_CONFIRM_TTL_MS = 60 * 1000; // 60 seconds post-confirm in milliseconds
 	private readonly MAX_ATTEMPTS = 5;
-	private readonly RATE_LIMIT_TTL = 60 * 60; // 1 hour in seconds
+	private readonly RATE_LIMIT_TTL_SECONDS = 60 * 60; // 1 hour in seconds
 	private readonly MAX_REQUESTS_PER_HOUR = 5;
 
 	constructor(
@@ -79,7 +79,7 @@ export class PhoneVerificationService {
 			purpose
 		);
 
-		await this.verificationRepo.save(verificationId, verificationData, this.VERIFICATION_TTL * 1000);
+		await this.verificationRepo.save(verificationId, verificationData, this.VERIFICATION_TTL_MS);
 
 		await this.incrementRateLimit(normalizedPhone);
 
@@ -100,7 +100,7 @@ export class PhoneVerificationService {
 		await this.rateLimitService.checkLimit(
 			key,
 			this.MAX_REQUESTS_PER_HOUR,
-			this.RATE_LIMIT_TTL,
+			this.RATE_LIMIT_TTL_SECONDS,
 			errorMessage
 		);
 	}
@@ -111,7 +111,7 @@ export class PhoneVerificationService {
 	 */
 	private async incrementRateLimit(phoneNumber: string): Promise<void> {
 		const key = `rate_limit:${phoneNumber}`;
-		await this.rateLimitService.increment(key, this.RATE_LIMIT_TTL);
+		await this.rateLimitService.increment(key, this.RATE_LIMIT_TTL_SECONDS);
 	}
 
 	/**
@@ -127,7 +127,7 @@ export class PhoneVerificationService {
 		const verificationId = uuidv4();
 		const code = this.codeGenerator.generateCode();
 		const hashedCode = await this.codeGenerator.hashCode(code);
-		const expirationTime = Date.now() + this.VERIFICATION_TTL * 1000;
+		const expirationTime = Date.now() + this.VERIFICATION_TTL_MS;
 
 		const verificationData: VerificationCode = {
 			phoneNumber,
@@ -236,8 +236,17 @@ export class PhoneVerificationService {
 		verificationId: string,
 		verificationData: VerificationCode
 	): Promise<void> {
+		const remainingMs = verificationData.expiresAt - Date.now();
+		if (remainingMs <= 0) {
+			await this.verificationRepo.delete(verificationId);
+			return;
+		}
 		verificationData.verified = true;
-		await this.verificationRepo.update(verificationId, verificationData, this.POST_CONFIRM_TTL);
+		await this.verificationRepo.update(
+			verificationId,
+			verificationData,
+			Math.min(this.POST_CONFIRM_TTL_MS, remainingMs)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- After a successful OTP confirm, the `verificationId` was kept in Redis with the full 15-minute TTL, allowing anyone who intercepted it to call `/register` or `/login` without having seen the OTP
- Replaced the residual TTL in `markVerificationAsConfirmed` with a fixed 60-second window (`POST_CONFIRM_TTL`) so the `verificationId` expires shortly after confirmation if not immediately consumed
- Added unit tests for both `confirmRegistrationVerification` and `confirmLoginVerification` asserting the 60-second TTL is passed to `verificationRepo.update`

## Test plan
- [x] Unit tests green (649 tests, 47 suites)
- [ ] E2E tests green
- [ ] Lint clean

Closes WHISPR-686