### PR TITLE
docs(phone-verification): add 429 response and clarify 400 descriptions on confirm endpoints

### DIFF
--- a/src/modules/phone-verification/controllers/phone-verification.controller.ts
+++ b/src/modules/phone-verification/controllers/phone-verification.controller.ts
@@ -35,7 +35,10 @@ export class PhoneVerificationController {
 	@ApiOperation({ summary: 'Confirm registration verification code' })
 	@ApiBody({ type: VerificationConfirmDto, examples: VERIFICATION_CONFIRM_EXAMPLES })
 	@ApiResponse({ status: 200, description: 'Verification code confirmed' })
-	@ApiResponse({ status: 400, description: 'Incorrect verification code — or invalid/expired verification session' })
+	@ApiResponse({
+		status: 400,
+		description: 'Incorrect verification code — or invalid/expired verification session',
+	})
 	@ApiResponse({ status: 429, description: 'Too many failed attempts — verification blocked' })
 	async confirmRegistrationVerification(
 		@Body() dto: VerificationConfirmDto
@@ -61,7 +64,10 @@ export class PhoneVerificationController {
 	@ApiOperation({ summary: 'Confirm login verification code' })
 	@ApiBody({ type: VerificationConfirmDto, examples: VERIFICATION_CONFIRM_EXAMPLES })
 	@ApiResponse({ status: 200, description: 'Verification code confirmed' })
-	@ApiResponse({ status: 400, description: 'Incorrect verification code — or invalid/expired verification session' })
+	@ApiResponse({
+		status: 400,
+		description: 'Incorrect verification code — or invalid/expired verification session',
+	})
 	@ApiResponse({ status: 429, description: 'Too many failed attempts — verification blocked' })
 	async confirmLoginVerification(@Body() dto: VerificationConfirmDto) {
 		return this.phoneVerificationService.confirmLoginVerification(dto);

--- a/src/modules/phone-verification/controllers/phone-verification.controller.ts
+++ b/src/modules/phone-verification/controllers/phone-verification.controller.ts
@@ -35,7 +35,8 @@ export class PhoneVerificationController {
 	@ApiOperation({ summary: 'Confirm registration verification code' })
 	@ApiBody({ type: VerificationConfirmDto, examples: VERIFICATION_CONFIRM_EXAMPLES })
 	@ApiResponse({ status: 200, description: 'Verification code confirmed' })
-	@ApiResponse({ status: 400, description: 'Invalid or expired verification code' })
+	@ApiResponse({ status: 400, description: 'Incorrect verification code — or invalid/expired verification session' })
+	@ApiResponse({ status: 429, description: 'Too many failed attempts — verification blocked' })
 	async confirmRegistrationVerification(
 		@Body() dto: VerificationConfirmDto
 	): Promise<VerificationConfirmResponseDto> {
@@ -60,7 +61,8 @@ export class PhoneVerificationController {
 	@ApiOperation({ summary: 'Confirm login verification code' })
 	@ApiBody({ type: VerificationConfirmDto, examples: VERIFICATION_CONFIRM_EXAMPLES })
 	@ApiResponse({ status: 200, description: 'Verification code confirmed' })
-	@ApiResponse({ status: 400, description: 'Invalid or expired verification code' })
+	@ApiResponse({ status: 400, description: 'Incorrect verification code — or invalid/expired verification session' })
+	@ApiResponse({ status: 429, description: 'Too many failed attempts — verification blocked' })
 	async confirmLoginVerification(@Body() dto: VerificationConfirmDto) {
 		return this.phoneVerificationService.confirmLoginVerification(dto);
 	}

--- a/src/modules/phone-verification/controllers/phone-verification.controller.ts
+++ b/src/modules/phone-verification/controllers/phone-verification.controller.ts
@@ -39,7 +39,10 @@ export class PhoneVerificationController {
 		status: 400,
 		description: 'Incorrect verification code — or invalid/expired verification session',
 	})
-	@ApiResponse({ status: 429, description: 'Too many failed attempts — verification blocked' })
+	@ApiResponse({
+		status: 429,
+		description: 'Too many verification attempts — session deleted, subsequent requests return 400',
+	})
 	async confirmRegistrationVerification(
 		@Body() dto: VerificationConfirmDto
 	): Promise<VerificationConfirmResponseDto> {
@@ -66,9 +69,12 @@ export class PhoneVerificationController {
 	@ApiResponse({ status: 200, description: 'Verification code confirmed' })
 	@ApiResponse({
 		status: 400,
-		description: 'Incorrect verification code — or invalid/expired verification session',
+		description: 'Incorrect verification code, invalid/expired verification session, or user not found',
 	})
-	@ApiResponse({ status: 429, description: 'Too many failed attempts — verification blocked' })
+	@ApiResponse({
+		status: 429,
+		description: 'Too many verification attempts — session deleted, subsequent requests return 400',
+	})
 	async confirmLoginVerification(@Body() dto: VerificationConfirmDto) {
 		return this.phoneVerificationService.confirmLoginVerification(dto);
 	}


### PR DESCRIPTION
## Summary
- Add `@ApiResponse({ status: 429 })` on `POST /verify/register/confirm` and `POST /verify/login/confirm` — `verifyCode` raises `TOO_MANY_REQUESTS` after 5 failed attempts but the decorator was missing
- Clarify the 400 description to cover both cases: incorrect code and invalid/expired verification session

## Test plan
- [x] Unit tests green (`npx jest --testPathPatterns="phone-verification" --no-coverage` — 72 tests passed)
- [ ] E2E tests green
- [x] Lint clean (pre-commit hook passed)

Closes WHISPR-688