### PR TITLE
fix(phone-verification): reject re-submission of code on already-confirmed verificationId

### DIFF
--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
@@ -294,6 +294,38 @@ describe('PhoneVerificationService', () => {
 			expect(result).toEqual(verificationData);
 		});
 
+		it('should throw BadRequestException when already verified and a non-empty code is submitted', async () => {
+			const verificationData: VerificationCode = {
+				phoneNumber: '+33612345678',
+				hashedCode: 'hashed',
+				purpose: 'login',
+				attempts: 0,
+				expiresAt: Date.now() + 900000,
+				verified: true,
+			};
+			mockVerificationRepo.findById.mockResolvedValue(verificationData);
+
+			await expect(service.verifyCode('verification-id', '123456')).rejects.toThrow(
+				new BadRequestException('Verification code has already been confirmed')
+			);
+		});
+
+		it('should throw BadRequestException when already verified and an incorrect code is submitted', async () => {
+			const verificationData: VerificationCode = {
+				phoneNumber: '+33612345678',
+				hashedCode: 'hashed',
+				purpose: 'registration',
+				attempts: 0,
+				expiresAt: Date.now() + 900000,
+				verified: true,
+			};
+			mockVerificationRepo.findById.mockResolvedValue(verificationData);
+
+			await expect(service.verifyCode('verification-id', 'wrong')).rejects.toThrow(
+				new BadRequestException('Verification code has already been confirmed')
+			);
+		});
+
 		it('should accept OTP bypass code when configured', async () => {
 			service = await buildModule({ OTP_BYPASS_CODE: 'BYPASS123' });
 			const verificationData: VerificationCode = {

--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
@@ -196,9 +196,11 @@ export class PhoneVerificationService {
 			throw new BadRequestException('Invalid or expired verification code');
 		}
 
-		// If already verified and no code provided, return the data
-		if (verificationData.verified && code === '') {
-			return verificationData;
+		if (verificationData.verified) {
+			if (code === '') {
+				return verificationData;
+			}
+			throw new BadRequestException('Verification code has already been confirmed');
 		}
 
 		if (verificationData.attempts >= this.MAX_ATTEMPTS) {


### PR DESCRIPTION
## Summary
- The existing guard in `verifyCode` only short-circuited when `code === ''` (a latent internal path with no active caller). A non-empty code submitted against an already-confirmed verificationId would fall through to hash comparison instead of being rejected.
- Added an explicit guard that throws `BadRequestException('Verification code has already been confirmed')` when `verified === true` and `code !== ''`.
- The `code === ''` branch is preserved unchanged to avoid unintended side-effects.

## Test plan
- [x] Unit tests added for re-submission with a correct code on an already-confirmed verificationId (expects 400)
- [x] Unit tests added for re-submission with an incorrect code on an already-confirmed verificationId (expects 400)
- [x] Existing test for the `code === ''` path remains green
- [x] Full unit test suite green (649 tests)
- [x] SonarCloud quality gate OK (100% coverage on new code, 0 BLOCKER/HIGH issues)
- [x] Lint clean

Closes WHISPR-687