### PR TITLE
chore(ci): restrict triggers to main branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: 🚀 CI Pipeline
 
 on:
   push:
-    branches: [main, develop, deploy/preprod]
+    branches: [main]
     paths-ignore:
       - 'k8s/**'
       - '**.md'
       - 'documentation/**'
       - '.github/workflows/cd.yml'
   pull_request:
-    branches: [main, develop, deploy/preprod]
+    branches: [main]
     paths-ignore:
       - 'k8s/**'
       - '**.md'
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       ref: ${{ github.ref }}
-      should_deploy: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod') && github.event_name == 'push' }}
+      should_deploy: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
@@ -51,7 +51,7 @@ jobs:
     uses: ./.github/workflows/trivy.yml
     with:
       ref: ${{ github.ref }}
-      should_deploy: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod') && github.event_name == 'push' }}
+      should_deploy: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
 
   # ================================
   # Docker Build
@@ -63,7 +63,7 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       ref: ${{ github.ref }}
-      should_deploy: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod') && github.event_name == 'push' }}
+      should_deploy: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
 
   # ================================
   # Deploy Gate (breaks the uses->uses chain forbidden by GitHub Actions)
@@ -72,7 +72,7 @@ jobs:
     name: 🔒 Deploy Gate
     runs-on: ubuntu-latest
     needs: [docker]
-    if: needs.docker.result == 'success' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/deploy/preprod') && github.event_name == 'push'
+    if: needs.docker.result == 'success' && github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - run: echo "Docker succeeded, proceeding to deploy"
 


### PR DESCRIPTION
## Summary
- Remove `deploy/preprod` and `develop` from `push` / `pull_request` triggers in `.github/workflows/ci.yml`
- Simplify `should_deploy` expressions (tests/security/docker jobs) and the `deploy_gate` condition to reference `refs/heads/main` only
- Align the CI with the project's **GitHub Flow** — a single long-lived `main` branch, with environment promotion handled by `cd.yml` via immutable image tags in the `infrastructure` repo, not via mirror branches

## Context
The `deploy/preprod` branch was added to CI triggers by WHISPR-697, but the features it carried have since been reintegrated into `main`. Keeping it in the triggers implements a GitFlow-style model (long-lived branch per environment) which conflicts with the GitHub Flow approach followed by the rest of the project. This also closes the design gap that the declined PR #156 was trying to work around.

`cd.yml` is intentionally left unchanged for this iteration — it keeps updating all environment manifests as today. A broader `cd.yml` refactor (environment input, `ref` removal, Kargo adoption) is tracked by WHISPR-725 and WHISPR-713.

## Test plan
- [ ] Unit tests green (ran via pre-push hook: 97/97 passing)
- [ ] E2E tests green (ran via pre-push hook)
- [ ] Lint clean
- [ ] CI pipeline runs on this PR (triggered by `pull_request` → `main`)
- [ ] SonarQube quality gate OK

Closes WHISPR-754
Supersedes #156