### PR TITLE
chore(gitignore): untrack .vscode/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,11 +32,7 @@ lerna-debug.log*
 *.sublime-workspace
 
 # IDE - VSCode
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode/
 
 # dotenv environment variable files
 .env

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-    "recommendations": [
-        "arjun.swagger-viewer"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.watcherExclude": {
-        "**/target": true
-    }
-}


### PR DESCRIPTION
## Summary

- Removes `.vscode/extensions.json` and `.vscode/settings.json` from Git tracking
- Simplifies the `.gitignore` VSCode section by dropping the whitelist exceptions (`!.vscode/settings.json`, `!.vscode/tasks.json`, `!.vscode/launch.json`, `!.vscode/extensions.json`) that were re-tracking IDE config files
- Replaces the pattern with a single `.vscode/` rule so every contributor's local IDE config stays out of the repo

IDE-specific configuration (editor preferences, recommended extensions) should not be versioned — it pollutes diffs and forces other contributors' VSCode setups to match.

## Test plan

- [x] `git ls-files .vscode/` returns empty after the change
- [x] `git check-ignore -v .vscode/settings.json` matches the new `.vscode/` rule
- [x] Local `.vscode/` edits no longer appear in `git status`
- [ ] CI green
- [ ] SonarQube quality gate OK

Closes WHISPR-755