### PR TITLE
fix(phone-auth): pass wrong-purpose message to BadRequestException

### DIFF
--- a/src/modules/phone-auth/dto/logout.dto.ts
+++ b/src/modules/phone-auth/dto/logout.dto.ts
@@ -1,13 +1,19 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional } from 'class-validator';
 
 export class LogoutDto {
-	@ApiProperty({ description: "Identifiant de l'appareil à déconnecter", required: false })
+	@ApiPropertyOptional({
+		description: 'ID of the device to log out',
+		example: '550e8400-e29b-41d4-a716-446655440001',
+	})
 	@IsString()
 	@IsOptional()
 	deviceId?: string;
 
-	@ApiProperty({ description: "Identifiant de l'utilisateur", required: false })
+	@ApiPropertyOptional({
+		description: 'ID of the user to log out',
+		example: '550e8400-e29b-41d4-a716-446655440000',
+	})
 	@IsString()
 	@IsOptional()
 	userId?: string;

--- a/src/modules/phone-auth/services/phone-authentication.service.ts
+++ b/src/modules/phone-auth/services/phone-authentication.service.ts
@@ -51,8 +51,7 @@ export class PhoneAuthenticationService {
 		const verificationData = await this.phoneVerificationService.getConfirmedVerification(verificationId);
 
 		if (verificationData.purpose !== purpose) {
-			this.getWrongPurposeMessage(purpose);
-			throw new BadRequestException();
+			throw new BadRequestException(this.getWrongPurposeMessage(purpose));
 		}
 
 		return verificationData.phoneNumber;

--- a/src/modules/phone-verification/controllers/phone-verification.controller.ts
+++ b/src/modules/phone-verification/controllers/phone-verification.controller.ts
@@ -3,6 +3,7 @@ import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import {
 	VerificationConfirmDto,
 	VerificationConfirmResponseDto,
+	VerificationLoginResponseDto,
 	VerificationRequestDto,
 	VerificationRequestResponseDto,
 } from '../dto';
@@ -34,7 +35,11 @@ export class PhoneVerificationController {
 	@HttpCode(HttpStatus.OK)
 	@ApiOperation({ summary: 'Confirm registration verification code' })
 	@ApiBody({ type: VerificationConfirmDto, examples: VERIFICATION_CONFIRM_EXAMPLES })
-	@ApiResponse({ status: 200, description: 'Verification code confirmed' })
+	@ApiResponse({
+		status: 200,
+		description: 'Verification code confirmed',
+		type: VerificationConfirmResponseDto,
+	})
 	@ApiResponse({
 		status: 400,
 		description: 'Incorrect verification code — or invalid/expired verification session',
@@ -66,7 +71,11 @@ export class PhoneVerificationController {
 	@HttpCode(HttpStatus.OK)
 	@ApiOperation({ summary: 'Confirm login verification code' })
 	@ApiBody({ type: VerificationConfirmDto, examples: VERIFICATION_CONFIRM_EXAMPLES })
-	@ApiResponse({ status: 200, description: 'Verification code confirmed' })
+	@ApiResponse({
+		status: 200,
+		description: 'Verification code confirmed',
+		type: VerificationLoginResponseDto,
+	})
 	@ApiResponse({
 		status: 400,
 		description: 'Incorrect verification code, invalid/expired verification session, or user not found',
@@ -75,7 +84,9 @@ export class PhoneVerificationController {
 		status: 429,
 		description: 'Too many verification attempts — session deleted, subsequent requests return 400',
 	})
-	async confirmLoginVerification(@Body() dto: VerificationConfirmDto) {
+	async confirmLoginVerification(
+		@Body() dto: VerificationConfirmDto
+	): Promise<VerificationLoginResponseDto> {
 		return this.phoneVerificationService.confirmLoginVerification(dto);
 	}
 }


### PR DESCRIPTION
## Summary

### Bug fix
`PhoneAuthenticationService.verifyPhoneNumberForPurpose` was computing the wrong-purpose error message via `getWrongPurposeMessage(purpose)` but **discarding its return value**, then throwing an empty `BadRequestException()`. Clients were getting a generic `400 Bad Request` on register/login flows whenever the `verificationId` had been issued for a different purpose — no actionable error message.

**Before:**
```ts
if (verificationData.purpose !== purpose) {
    this.getWrongPurposeMessage(purpose); // return value ignored
    throw new BadRequestException();       // empty message
}
```

**After:**
```ts
if (verificationData.purpose !== purpose) {
    throw new BadRequestException(this.getWrongPurposeMessage(purpose));
}
```

### OpenAPI / Swagger improvements (embedded in same PR)
- `logout.dto.ts` — switch from `@ApiProperty({required: false})` to `@ApiPropertyOptional`, translate descriptions from FR to EN for consistency with the rest of the API, add UUID examples.
- `phone-verification.controller.ts` — add the missing `type:` field on the `@ApiResponse` of `confirmRegistrationVerification` (→ `VerificationConfirmResponseDto`) and `confirmLoginVerification` (→ `VerificationLoginResponseDto`). Without `type:` the response schema was not emitted to the generated OpenAPI document.
- `phone-verification.controller.ts` — add explicit `Promise<VerificationLoginResponseDto>` return type on `confirmLoginVerification` for consistency with other handlers.

## Test plan
- [x] Unit tests green — phone-auth + phone-verification suites: 92/92 passing
- [x] Pre-push hook full unit test suite: passing
- [x] E2E tests green (pre-push hook)
- [x] Lint/format clean (husky pre-commit applied)

No existing test was asserting the previous empty-exception behaviour, so the fix is safe.

Closes WHISPR-758