### PR TITLE
[WHISPR-1236] fix(tokens): pass aud and iss as sign options for ws-token

### DIFF
--- a/src/modules/tokens/services/tokens.service.spec.ts
+++ b/src/modules/tokens/services/tokens.service.spec.ts
@@ -185,7 +185,7 @@ describe('TokensService', () => {
 			expect(jwtService.sign).toHaveBeenCalledTimes(1);
 		});
 
-		it('signs the payload with aud=ws, iss=whispr-auth, sub and deviceId', () => {
+		it('puts sub and deviceId in the payload', () => {
 			jwtService.sign.mockReturnValue('ws-jwt');
 
 			service.generateWsToken('user-id', 'device-id');
@@ -194,9 +194,43 @@ describe('TokensService', () => {
 			expect(payload).toMatchObject({
 				sub: 'user-id',
 				deviceId: 'device-id',
-				aud: 'ws',
-				iss: 'whispr-auth',
 			});
+		});
+
+		// WHISPR-1236 : aud et iss DOIVENT être passés en options de sign()
+		// et NON dans le payload. La lib jsonwebtoken throw "Bad
+		// options.audience option" si les deux coexistent, ce qui se produit
+		// dès que JWT_AUDIENCE est défini globalement (preprod, prod, e2e).
+		it('passes aud=ws and iss=whispr-auth via sign options, not via payload', () => {
+			jwtService.sign.mockReturnValue('ws-jwt');
+
+			service.generateWsToken('user-id', 'device-id');
+
+			const [payload, options] = jwtService.sign.mock.calls[0];
+			expect(payload).not.toHaveProperty('aud');
+			expect(payload).not.toHaveProperty('iss');
+			expect(options).toMatchObject({ audience: 'ws', issuer: 'whispr-auth' });
+		});
+
+		// WHISPR-1236 : test de régression. Reproduit le throw réel de
+		// jsonwebtoken quand payload.aud et options.audience coexistent —
+		// si quelqu'un réintroduit aud dans le payload, ce test casse.
+		it('does not trigger the jsonwebtoken aud-conflict error', () => {
+			jwtService.sign.mockImplementation((payload: any, options: any) => {
+				if (
+					payload &&
+					Object.prototype.hasOwnProperty.call(payload, 'aud') &&
+					options &&
+					options.audience !== undefined
+				) {
+					throw new Error(
+						'Bad "options.audience" option. The payload already has an "aud" property.'
+					);
+				}
+				return 'ws-jwt';
+			});
+
+			expect(() => service.generateWsToken('user-id', 'device-id')).not.toThrow();
 		});
 
 		it('sets exp to iat + 60s', () => {

--- a/src/modules/tokens/services/tokens.service.ts
+++ b/src/modules/tokens/services/tokens.service.ts
@@ -85,11 +85,13 @@ export class TokensService {
 
 	generateWsToken(userId: string, deviceId: string): { wsToken: string; expiresIn: number } {
 		const now = Math.floor(Date.now() / 1000);
+		// aud/iss passent en options de sign() — pas dans le payload — pour
+		// overrider proprement les valeurs globales injectées par
+		// jwtModuleOptionsFactory. La lib jsonwebtoken refuse de définir un
+		// claim s'il existe déjà dans le payload (WHISPR-1236).
 		const payload = {
 			sub: userId,
 			deviceId,
-			aud: TokensService.WS_TOKEN_AUDIENCE,
-			iss: TokensService.TOKEN_ISSUER,
 			iat: now,
 			exp: now + this.WS_TOKEN_TTL,
 		};
@@ -97,6 +99,8 @@ export class TokensService {
 		const wsToken = this.jwtService.sign(payload, {
 			algorithm: 'ES256',
 			keyid: this.jwksService.getKid(),
+			audience: TokensService.WS_TOKEN_AUDIENCE,
+			issuer: TokensService.TOKEN_ISSUER,
 		});
 
 		return { wsToken, expiresIn: this.WS_TOKEN_TTL };

--- a/test/ws-token.e2e-spec.ts
+++ b/test/ws-token.e2e-spec.ts
@@ -1,0 +1,83 @@
+/**
+ * E2E tests for POST /auth/v1/tokens/ws-token (WHISPR-1236).
+ *
+ * Exercises the real TokensService + JwtService stack with JWT_AUDIENCE /
+ * JWT_ISSUER set in the environment (see test/setup-e2e.ts). A previous
+ * version put aud and iss inside the payload, which collided with the
+ * audience/issuer options injected globally by jwtModuleOptionsFactory and
+ * made jsonwebtoken throw `Bad "options.audience" option`. This e2e blocks
+ * any future regression by hitting the real signing path.
+ */
+import { INestApplication } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+import { JwtAuthGuard } from '../src/modules/tokens/guards/jwt-auth.guard';
+import { createTestApp } from './helpers/create-test-app';
+import { createTestModule } from './helpers/create-test-module';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const request = require('supertest');
+
+const TEST_USER_ID = 'user-uuid';
+const TEST_DEVICE_ID = 'device-uuid';
+
+describe('POST /auth/v1/tokens/ws-token (e2e)', () => {
+	let app: INestApplication;
+
+	const buildApp = async () => {
+		const moduleFixture = await createTestModule({
+			guards: [
+				{
+					guard: JwtAuthGuard,
+					useValue: {
+						canActivate: (ctx: any) => {
+							const req = ctx.switchToHttp().getRequest();
+							req.user = { sub: TEST_USER_ID, deviceId: TEST_DEVICE_ID };
+							return true;
+						},
+					},
+				},
+			],
+		});
+		return createTestApp(moduleFixture);
+	};
+
+	beforeEach(async () => {
+		app = await buildApp();
+	});
+
+	afterEach(async () => {
+		if (app) await app.close();
+		jest.clearAllMocks();
+	});
+
+	it('returns 200 with a signed ws-token even when JWT_AUDIENCE is set globally', async () => {
+		const res = await request(app.getHttpServer())
+			.post('/auth/v1/tokens/ws-token')
+			.set('Authorization', 'Bearer ignored-by-mocked-guard')
+			.expect(200);
+
+		expect(res.body).toEqual({
+			wsToken: expect.any(String),
+			expiresIn: 60,
+		});
+	});
+
+	it('signs a ws-token whose aud and iss are the WS-specific values, not the global JWT_AUDIENCE / JWT_ISSUER', async () => {
+		const res = await request(app.getHttpServer())
+			.post('/auth/v1/tokens/ws-token')
+			.set('Authorization', 'Bearer ignored-by-mocked-guard')
+			.expect(200);
+
+		const decoded = jwt.decode(res.body.wsToken) as jwt.JwtPayload;
+		expect(decoded).toMatchObject({
+			sub: TEST_USER_ID,
+			deviceId: TEST_DEVICE_ID,
+			aud: 'ws',
+			iss: 'whispr-auth',
+		});
+		// Sanity check: the global JWT_AUDIENCE from setup-e2e.ts must NOT
+		// leak into a ws-token (messaging-service rejects anything other
+		// than nil | "whispr" | "ws").
+		expect(decoded.aud).not.toBe('whispr-test-audience');
+	});
+});


### PR DESCRIPTION
## Summary

- `POST /auth/v1/tokens/ws-token` retournait HTTP 500 en preprod (`Bad "options.audience" option. The payload already has an "aud" property.`).
- Cause : `generateWsToken` mettait `aud` et `iss` dans le payload alors que `jwtModuleOptionsFactory` injecte déjà `audience` / `issuer` au niveau du `JwtModule` quand `JWT_AUDIENCE` / `JWT_ISSUER` sont définis (preprod, prod, e2e). `jsonwebtoken` refuse de surcharger un claim déjà présent.
- Fix : déplacer `aud` et `iss` du payload vers les options de `JwtService.sign()`, ce qui override explicitement les valeurs globales avec `audience: "ws"` / `issuer: "whispr-auth"`.

## Pourquoi ce n'a pas été détecté dans WHISPR-1214

- En dev local, `JWT_AUDIENCE` n'est pas défini → pas de conflit.
- Aucun e2e ne couvrait `/tokens/ws-token`. Ce PR ajoute `test/ws-token.e2e-spec.ts` qui hit le **vrai** chemin de signature avec `JWT_AUDIENCE` set (cf. `test/setup-e2e.ts:38`), donc une régression future planterait en CI.

## Test plan

- [x] Unit tests verts (`npx jest --no-coverage` → 757/757)
- [x] E2E verts (`npx jest --config test/jest-e2e.json --no-coverage` → 110/110)
- [x] Test de régression unitaire qui simule le throw réel de `jsonwebtoken` quand `payload.aud` et `options.audience` coexistent
- [x] Test e2e qui décode le ws-token et vérifie `aud === "ws"`, `iss === "whispr-auth"` (pas `JWT_AUDIENCE` global)
- [x] Lint + Prettier clean (husky pre-commit)

Closes WHISPR-1236