### PR TITLE
fix(tokens): inherit JWT_ISSUER for ws-token instead of hardcoded constant

### DIFF
--- a/src/modules/tokens/services/tokens.service.spec.ts
+++ b/src/modules/tokens/services/tokens.service.spec.ts
@@ -197,11 +197,15 @@ describe('TokensService', () => {
 			});
 		});
 
-		// WHISPR-1236 : aud et iss DOIVENT être passés en options de sign()
-		// et NON dans le payload. La lib jsonwebtoken throw "Bad
-		// options.audience option" si les deux coexistent, ce qui se produit
-		// dès que JWT_AUDIENCE est défini globalement (preprod, prod, e2e).
-		it('passes aud=ws and iss=whispr-auth via sign options, not via payload', () => {
+		// WHISPR-1236 : aud DOIT être passé en option de sign() et NON dans le
+		// payload. La lib jsonwebtoken throw "Bad options.audience option" si
+		// les deux coexistent, ce qui se produit dès que JWT_AUDIENCE est
+		// défini globalement (preprod, prod, e2e).
+		// WHISPR-1249 : iss n'est PAS overridé — la valeur globale JWT_ISSUER
+		// (injectée par jwtModuleOptionsFactory) doit s'appliquer pour que le
+		// ws-token partage le même iss que les access tokens HTTP, sinon
+		// messaging-service rejette le handshake.
+		it('passes aud=ws via sign options and does NOT override issuer', () => {
 			jwtService.sign.mockReturnValue('ws-jwt');
 
 			service.generateWsToken('user-id', 'device-id');
@@ -209,7 +213,8 @@ describe('TokensService', () => {
 			const [payload, options] = jwtService.sign.mock.calls[0];
 			expect(payload).not.toHaveProperty('aud');
 			expect(payload).not.toHaveProperty('iss');
-			expect(options).toMatchObject({ audience: 'ws', issuer: 'whispr-auth' });
+			expect(options).toMatchObject({ audience: 'ws' });
+			expect(options).not.toHaveProperty('issuer');
 		});
 
 		// WHISPR-1236 : test de régression. Reproduit le throw réel de

--- a/src/modules/tokens/services/tokens.service.ts
+++ b/src/modules/tokens/services/tokens.service.ts
@@ -17,7 +17,6 @@ export class TokensService {
 	// breadcrumbs le capturent ; 60 s borne le préjudice d'une fuite.
 	private readonly WS_TOKEN_TTL = 60;
 	private static readonly WS_TOKEN_AUDIENCE = 'ws';
-	private static readonly TOKEN_ISSUER = 'whispr-auth';
 	/**
 	 * TTL des clés de revocation (WHISPR-919).
 	 * Doit être supérieur au TTL maximum d'un refresh token pour garantir
@@ -85,10 +84,11 @@ export class TokensService {
 
 	generateWsToken(userId: string, deviceId: string): { wsToken: string; expiresIn: number } {
 		const now = Math.floor(Date.now() / 1000);
-		// aud/iss passent en options de sign() — pas dans le payload — pour
-		// overrider proprement les valeurs globales injectées par
-		// jwtModuleOptionsFactory. La lib jsonwebtoken refuse de définir un
-		// claim s'il existe déjà dans le payload (WHISPR-1236).
+		// aud passe en option pour overrider la valeur globale (HTTP) avec "ws"
+		// — sans collision avec le payload (WHISPR-1236). iss n'est PAS overridé :
+		// messaging-service valide iss strict contre la même valeur que pour
+		// les access tokens HTTP, donc on laisse jwtModuleOptionsFactory injecter
+		// JWT_ISSUER (WHISPR-1249).
 		const payload = {
 			sub: userId,
 			deviceId,
@@ -100,7 +100,6 @@ export class TokensService {
 			algorithm: 'ES256',
 			keyid: this.jwksService.getKid(),
 			audience: TokensService.WS_TOKEN_AUDIENCE,
-			issuer: TokensService.TOKEN_ISSUER,
 		});
 
 		return { wsToken, expiresIn: this.WS_TOKEN_TTL };

--- a/test/ws-token.e2e-spec.ts
+++ b/test/ws-token.e2e-spec.ts
@@ -1,12 +1,14 @@
 /**
- * E2E tests for POST /auth/v1/tokens/ws-token (WHISPR-1236).
+ * E2E tests for POST /auth/v1/tokens/ws-token (WHISPR-1236, WHISPR-1249).
  *
  * Exercises the real TokensService + JwtService stack with JWT_AUDIENCE /
- * JWT_ISSUER set in the environment (see test/setup-e2e.ts). A previous
- * version put aud and iss inside the payload, which collided with the
- * audience/issuer options injected globally by jwtModuleOptionsFactory and
- * made jsonwebtoken throw `Bad "options.audience" option`. This e2e blocks
- * any future regression by hitting the real signing path.
+ * JWT_ISSUER set in the environment (see test/setup-e2e.ts).
+ *
+ * - WHISPR-1236 : aud="ws" must be passed in sign() options, not the payload,
+ *   otherwise jsonwebtoken throws on the audience collision.
+ * - WHISPR-1249 : iss must inherit the global JWT_ISSUER (same value as the
+ *   access tokens) — messaging-service validates iss strict against that
+ *   value and rejects anything else.
  */
 import { INestApplication } from '@nestjs/common';
 import * as jwt from 'jsonwebtoken';
@@ -62,7 +64,7 @@ describe('POST /auth/v1/tokens/ws-token (e2e)', () => {
 		});
 	});
 
-	it('signs a ws-token whose aud and iss are the WS-specific values, not the global JWT_AUDIENCE / JWT_ISSUER', async () => {
+	it('signs a ws-token with aud="ws" and iss inherited from the global JWT_ISSUER', async () => {
 		const res = await request(app.getHttpServer())
 			.post('/auth/v1/tokens/ws-token')
 			.set('Authorization', 'Bearer ignored-by-mocked-guard')
@@ -72,12 +74,15 @@ describe('POST /auth/v1/tokens/ws-token (e2e)', () => {
 		expect(decoded).toMatchObject({
 			sub: TEST_USER_ID,
 			deviceId: TEST_DEVICE_ID,
+			// WHISPR-1236 : aud must be "ws", not the global JWT_AUDIENCE.
 			aud: 'ws',
-			iss: 'whispr-auth',
+			// WHISPR-1249 : iss MUST be the global JWT_ISSUER (same value the
+			// access tokens carry) so messaging-service accepts the handshake.
+			iss: process.env.JWT_ISSUER,
 		});
 		// Sanity check: the global JWT_AUDIENCE from setup-e2e.ts must NOT
 		// leak into a ws-token (messaging-service rejects anything other
 		// than nil | "whispr" | "ws").
-		expect(decoded.aud).not.toBe('whispr-test-audience');
+		expect(decoded.aud).not.toBe(process.env.JWT_AUDIENCE);
 	});
 });


### PR DESCRIPTION
## Summary

- Suite à WHISPR-1236, le ws-token est bien signé sans 500, mais `messaging-service` (Phoenix/Joken) **rejette le handshake** parce que le ws-token porte `iss="whispr-auth"` (constante hardcodée) au lieu de la valeur globale `JWT_ISSUER` (par ex. `https://auth.whispr.roadmvn.com` en preprod). `messaging-service` valide `iss` strict contre la même valeur que celle des access tokens HTTP.
- Fix : retirer l'override `issuer:` dans `generateWsToken` et la constante morte `TOKEN_ISSUER`. La config globale `JWT_ISSUER` (injectée par `jwtModuleOptionsFactory`) s'applique alors automatiquement, et le ws-token partage le même `iss` que les access tokens.
- `audience` reste overridé (`"ws"` ≠ valeur HTTP globale).

## Garantie de présence de JWT_ISSUER

`jwt.config.ts:9-12` throw `JWT_ISSUER is required in production` au boot quand `NODE_ENV=production`. Donc en prod et preprod, le pod ne démarre pas si la variable manque → aucun risque de signer avec un `iss` vide. En e2e, `JWT_ISSUER` est défini par `test/setup-e2e.ts:37`. En dev local pur, il reste optionnel (comportement existant).

## Test plan

- [x] Unit tests : 757/757 verts (`npx jest --no-coverage`)
- [x] E2E : 110/110 verts (`npx jest --config test/jest-e2e.json --no-coverage`)
- [x] Test unit `passes aud=ws via sign options and does NOT override issuer` mis à jour pour vérifier que `options.issuer` est absent
- [x] Test e2e mis à jour pour décoder le ws-token et asserter `iss === process.env.JWT_ISSUER`
- [x] Test de régression WHISPR-1236 (`does not trigger the jsonwebtoken aud-conflict error`) toujours présent
- [x] Lint + Prettier clean (husky pre-commit)

Closes WHISPR-1249