### PR TITLE
[WHISPR-1319] fix(auth): 2FA brute-force + TOTP replay + OTP log redaction

### DIFF
--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
@@ -245,7 +245,18 @@ export class PhoneVerificationService {
 		} catch (error) {
 			if (process.env.NODE_ENV !== 'test') {
 				this.logger.error('Failed to send verification code:', error);
-				this.logger.log(`Verification code for ${phoneNumber}: ${code}`);
+				// ne jamais logguer le code OTP en clair, meme sur echec d'envoi: en prod
+				// les logs sont aggreges et indexes, c'est equivalent a une fuite credential.
+				// On garde une trace de l'echec sans le code.
+				if (process.env.NODE_ENV === 'development') {
+					this.logger.debug(
+						`Verification code for ${phoneNumber}: ${code} (development-only, redacted in other envs)`
+					);
+				} else {
+					this.logger.log(
+						`Verification code generation succeeded for ${phoneNumber} but SMS delivery failed (code redacted)`
+					);
+				}
 			}
 		}
 	}

--- a/src/modules/phone-verification/strategies/sms-verification.strategy.ts
+++ b/src/modules/phone-verification/strategies/sms-verification.strategy.ts
@@ -30,7 +30,17 @@ export class SmsVerificationStrategy implements VerificationChannelStrategy {
 			// Log the error but don't fail - allow the verification process to continue
 			if (process.env.NODE_ENV !== 'test') {
 				this.logger.error(`Failed to send SMS to ${recipient}:`, error);
-				this.logger.log(`Verification code for ${recipient}: ${code}`);
+				// ne pas exposer le code en clair dans les logs prod/staging.
+				// uniquement en development local pour faciliter le debug manuel.
+				if (process.env.NODE_ENV === 'development') {
+					this.logger.debug(
+						`Verification code for ${recipient}: ${code} (development-only, redacted in other envs)`
+					);
+				} else {
+					this.logger.log(
+						`Verification code generation succeeded for ${recipient} but SMS delivery failed (code redacted)`
+					);
+				}
 			}
 			// Re-throw in production to handle properly
 			if (process.env.NODE_ENV === 'production') {

--- a/src/modules/two-factor-authentication/services/two-factor-authentication.service.spec.ts
+++ b/src/modules/two-factor-authentication/services/two-factor-authentication.service.spec.ts
@@ -1,8 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, HttpException, HttpStatus, UnauthorizedException } from '@nestjs/common';
 import { TwoFactorAuthenticationService } from './two-factor-authentication.service';
 import { UserAuthService } from '../../common/services/user-auth.service';
 import { BackupCodesService } from '../backup-codes/backup-codes.service';
+import { CacheService } from '../../cache/cache.service';
 import * as speakeasy from 'speakeasy';
 import * as QRCode from 'qrcode';
 
@@ -24,6 +25,17 @@ describe('TwoFactorAuthenticationService', () => {
 		getRemainingCodesCount: jest.fn(),
 	};
 
+	// par defaut: rate limit non atteint. les tests qui veulent simuler un autre
+	// etat overriden les mocks individuellement.
+	const mockCacheService = {
+		get: jest.fn().mockResolvedValue(null),
+		set: jest.fn().mockResolvedValue(undefined),
+		del: jest.fn().mockResolvedValue(undefined),
+		incr: jest.fn().mockResolvedValue(1),
+		expire: jest.fn().mockResolvedValue(undefined),
+		exists: jest.fn().mockResolvedValue(false),
+	};
+
 	const mockUser = {
 		id: 'user-id',
 		phoneNumber: '+33612345678',
@@ -34,12 +46,16 @@ describe('TwoFactorAuthenticationService', () => {
 
 	beforeEach(async () => {
 		jest.clearAllMocks();
+		mockCacheService.get.mockResolvedValue(null);
+		mockCacheService.exists.mockResolvedValue(false);
+		mockCacheService.incr.mockResolvedValue(1);
 
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
 				TwoFactorAuthenticationService,
 				{ provide: UserAuthService, useValue: mockUserAuthService },
 				{ provide: BackupCodesService, useValue: mockBackupCodesService },
+				{ provide: CacheService, useValue: mockCacheService },
 			],
 		}).compile();
 
@@ -187,6 +203,37 @@ describe('TwoFactorAuthenticationService', () => {
 			mockUserAuthService.findById.mockResolvedValue(null);
 
 			await expect(service.verifyTwoFactor('user-id', '123456')).rejects.toThrow(BadRequestException);
+		});
+
+		// WHISPR-1319 — rate limit per-user (5 attempts / 15 min)
+		it('should throw HttpException 429 when verify attempts already at the limit', async () => {
+			mockUserAuthService.findById.mockResolvedValue(userWith2FA);
+			mockCacheService.get.mockResolvedValue(5);
+
+			const promise = service.verifyTwoFactor('user-id', '000000');
+			await expect(promise).rejects.toBeInstanceOf(HttpException);
+			await expect(promise).rejects.toMatchObject({ status: HttpStatus.TOO_MANY_REQUESTS });
+			expect(speakeasy.totp.verify).not.toHaveBeenCalled();
+		});
+
+		it('should increment attempts counter on failed verify', async () => {
+			mockUserAuthService.findById.mockResolvedValue(userWith2FA);
+			(speakeasy.totp.verify as jest.Mock).mockReturnValue(false);
+			mockBackupCodesService.verifyBackupCode.mockResolvedValue(false);
+
+			const result = await service.verifyTwoFactor('user-id', '000000');
+
+			expect(result).toBe(false);
+			expect(mockCacheService.incr).toHaveBeenCalledWith('attempts:2fa:verify:user-id');
+		});
+
+		it('should reset attempts counter on successful TOTP verify', async () => {
+			mockUserAuthService.findById.mockResolvedValue(userWith2FA);
+			(speakeasy.totp.verify as jest.Mock).mockReturnValue(true);
+
+			await service.verifyTwoFactor('user-id', '123456');
+
+			expect(mockCacheService.del).toHaveBeenCalledWith('attempts:2fa:verify:user-id');
 		});
 	});
 

--- a/src/modules/two-factor-authentication/services/two-factor-authentication.service.spec.ts
+++ b/src/modules/two-factor-authentication/services/two-factor-authentication.service.spec.ts
@@ -235,6 +235,28 @@ describe('TwoFactorAuthenticationService', () => {
 
 			expect(mockCacheService.del).toHaveBeenCalledWith('attempts:2fa:verify:user-id');
 		});
+
+		// WHISPR-1319 — TOTP replay protection
+		it('should mark TOTP code as used on success', async () => {
+			mockUserAuthService.findById.mockResolvedValue(userWith2FA);
+			(speakeasy.totp.verify as jest.Mock).mockReturnValue(true);
+
+			await service.verifyTwoFactor('user-id', '123456');
+
+			expect(mockCacheService.set).toHaveBeenCalledWith(
+				expect.stringContaining('2fa:replay:user-id:'),
+				'1',
+				90
+			);
+		});
+
+		it('should reject replayed TOTP code within validity window', async () => {
+			mockUserAuthService.findById.mockResolvedValue(userWith2FA);
+			mockCacheService.exists.mockResolvedValue(true);
+
+			await expect(service.verifyTwoFactor('user-id', '123456')).rejects.toThrow(BadRequestException);
+			expect(speakeasy.totp.verify).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('disableTwoFactor', () => {

--- a/src/modules/two-factor-authentication/services/two-factor-authentication.service.ts
+++ b/src/modules/two-factor-authentication/services/two-factor-authentication.service.ts
@@ -5,6 +5,7 @@ import {
 	HttpException,
 	HttpStatus,
 } from '@nestjs/common';
+import { createHash } from 'crypto';
 import { UserAuthService } from '../../common/services/user-auth.service';
 import * as speakeasy from 'speakeasy';
 import * as QRCode from 'qrcode';
@@ -21,6 +22,9 @@ interface TwoFactorSetup {
 // (sans cap, ~1800 tentatives/h sont possibles avec un JWT valide).
 const VERIFY_ATTEMPTS_LIMIT = 5;
 const VERIFY_ATTEMPTS_TTL_SECONDS = 15 * 60; // 15 minutes
+// fenetre TOTP = 90s (window: 2 cote speakeasy = +/- 60s + step 30s).
+// Garder la trace du code utilise un peu plus longtemps que la fenetre suffit.
+const TOTP_REPLAY_TTL_SECONDS = 90;
 
 @Injectable()
 export class TwoFactorAuthenticationService {
@@ -56,6 +60,24 @@ export class TwoFactorAuthenticationService {
 
 	private async resetVerifyAttempts(userId: string): Promise<void> {
 		await this.cacheService.del(this.buildAttemptsKey(userId));
+	}
+
+	private buildReplayKey(userId: string, code: string): string {
+		// hash sha256 pour ne pas stocker le code TOTP en clair dans Redis,
+		// meme si la TTL est courte. userId prefixe sert de salt par-user.
+		const digest = createHash('sha256').update(`${userId}:${code}`).digest('hex');
+		return `2fa:replay:${userId}:${digest}`;
+	}
+
+	private async assertTotpNotReplayed(userId: string, code: string): Promise<void> {
+		const exists = await this.cacheService.exists(this.buildReplayKey(userId, code));
+		if (exists) {
+			throw new BadRequestException('Verification code already used');
+		}
+	}
+
+	private async markTotpAsUsed(userId: string, code: string): Promise<void> {
+		await this.cacheService.set(this.buildReplayKey(userId, code), '1', TOTP_REPLAY_TTL_SECONDS);
 	}
 
 	async setupTwoFactor(userId: string): Promise<TwoFactorSetup> {
@@ -140,6 +162,11 @@ export class TwoFactorAuthenticationService {
 		// quand la limite est atteinte.
 		await this.assertVerifyRateLimit(userId);
 
+		// WHISPR-1319: anti-replay — un meme code TOTP valide ne peut etre rejoue
+		// dans sa fenetre de validite (90s). Protege contre l'usage d'un code
+		// intercepte (ex. shoulder surfing, MITM transitoire).
+		await this.assertTotpNotReplayed(userId, token);
+
 		const isValidTOTP = speakeasy.totp.verify({
 			secret: user.twoFactorSecret,
 			encoding: 'base32',
@@ -148,6 +175,7 @@ export class TwoFactorAuthenticationService {
 		});
 
 		if (isValidTOTP) {
+			await this.markTotpAsUsed(userId, token);
 			await this.resetVerifyAttempts(userId);
 			return true;
 		}

--- a/src/modules/two-factor-authentication/services/two-factor-authentication.service.ts
+++ b/src/modules/two-factor-authentication/services/two-factor-authentication.service.ts
@@ -1,8 +1,15 @@
-import { Injectable, BadRequestException, UnauthorizedException } from '@nestjs/common';
+import {
+	Injectable,
+	BadRequestException,
+	UnauthorizedException,
+	HttpException,
+	HttpStatus,
+} from '@nestjs/common';
 import { UserAuthService } from '../../common/services/user-auth.service';
 import * as speakeasy from 'speakeasy';
 import * as QRCode from 'qrcode';
 import { BackupCodesService } from '../backup-codes/backup-codes.service';
+import { CacheService } from '../../cache/cache.service';
 
 interface TwoFactorSetup {
 	secret: string;
@@ -10,12 +17,46 @@ interface TwoFactorSetup {
 	qrCodeUrl: string;
 }
 
+// WHISPR-1319: rate limit per-user sur POST /2fa/verify pour bloquer le bruteforce
+// (sans cap, ~1800 tentatives/h sont possibles avec un JWT valide).
+const VERIFY_ATTEMPTS_LIMIT = 5;
+const VERIFY_ATTEMPTS_TTL_SECONDS = 15 * 60; // 15 minutes
+
 @Injectable()
 export class TwoFactorAuthenticationService {
 	constructor(
 		private readonly userAuthService: UserAuthService,
-		private readonly backupCodesService: BackupCodesService
+		private readonly backupCodesService: BackupCodesService,
+		private readonly cacheService: CacheService
 	) {}
+
+	private buildAttemptsKey(userId: string): string {
+		return `attempts:2fa:verify:${userId}`;
+	}
+
+	private async assertVerifyRateLimit(userId: string): Promise<void> {
+		const key = this.buildAttemptsKey(userId);
+		const current = await this.cacheService.get<number | string>(key);
+		const count = current ? Number.parseInt(String(current), 10) : 0;
+		if (Number.isFinite(count) && count >= VERIFY_ATTEMPTS_LIMIT) {
+			throw new HttpException(
+				'Trop de tentatives, réessayez dans 15 minutes',
+				HttpStatus.TOO_MANY_REQUESTS
+			);
+		}
+	}
+
+	private async incrementVerifyAttempts(userId: string): Promise<void> {
+		const key = this.buildAttemptsKey(userId);
+		const value = await this.cacheService.incr(key);
+		if (value === 1) {
+			await this.cacheService.expire(key, VERIFY_ATTEMPTS_TTL_SECONDS);
+		}
+	}
+
+	private async resetVerifyAttempts(userId: string): Promise<void> {
+		await this.cacheService.del(this.buildAttemptsKey(userId));
+	}
 
 	async setupTwoFactor(userId: string): Promise<TwoFactorSetup> {
 		const user = await this.userAuthService.findById(userId);
@@ -94,6 +135,11 @@ export class TwoFactorAuthenticationService {
 			throw new BadRequestException('Two-factor authentication is not configured');
 		}
 
+		// WHISPR-1319: rate limit per-user — bloque le bruteforce TOTP.
+		// Le check se fait AVANT la verif speakeasy pour ne pas valider de code
+		// quand la limite est atteinte.
+		await this.assertVerifyRateLimit(userId);
+
 		const isValidTOTP = speakeasy.totp.verify({
 			secret: user.twoFactorSecret,
 			encoding: 'base32',
@@ -102,10 +148,18 @@ export class TwoFactorAuthenticationService {
 		});
 
 		if (isValidTOTP) {
+			await this.resetVerifyAttempts(userId);
 			return true;
 		}
 
-		return this.backupCodesService.verifyBackupCode(userId, token);
+		const isValidBackup = await this.backupCodesService.verifyBackupCode(userId, token);
+		if (isValidBackup) {
+			await this.resetVerifyAttempts(userId);
+			return true;
+		}
+
+		await this.incrementVerifyAttempts(userId);
+		return false;
 	}
 
 	async disableTwoFactor(userId: string, token: string): Promise<void> {


### PR DESCRIPTION
## Summary

Trois fixes securite sur auth-service:

- **Rate limit per-user sur POST /2fa/verify** : 5 tentatives / 15min via Redis (`attempts:2fa:verify:<userId>`). Bloque le bruteforce TOTP qu'un JWT vole rendait possible (~1800 codes/h).
- **Anti-replay TOTP** : un code valide ne peut etre rejoue dans sa fenetre de validite (90s). Le hash sha256 du couple `userId:code` est stocke dans Redis avec TTL 90s.
- **Redaction OTP dans les logs** : le code OTP n'est plus loggue en clair sur echec SMS, sauf en `NODE_ENV=development`. Idem pour `SmsVerificationStrategy` qui avait un leak equivalent.

## Test plan

- [x] Unit tests verts (771 / 771)
- [x] E2E tests verts (110 / 110)
- [x] Lint + prettier clean
- [x] tsc --noEmit clean
- [ ] Sonar quality gate OK
- [ ] Copilot review processed

Closes WHISPR-1319