### PR TITLE
[WHISPR-1320] chore(deps): bump @nestjs/microservices CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,12 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nest-lab/throttler-storage-redis": "^1.2.0",
         "@nestjs/common": "^11.1.9",
         "@nestjs/config": "^4.0.3",
         "@nestjs/core": "^11.1.18",
         "@nestjs/jwt": "^11.0.1",
-        "@nestjs/microservices": "^11.1.16",
+        "@nestjs/microservices": "^11.1.19",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.9",
         "@nestjs/schedule": "^6.1.1",
@@ -34,8 +35,7 @@
         "rxjs": "^7.8.1",
         "speakeasy": "^2.0.0",
         "typeorm": "^0.3.24",
-        "uuid": "^9.0.0",
-        "@nest-lab/throttler-storage-redis": "^1.2.0"
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.12",
@@ -2442,6 +2442,39 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nest-lab/throttler-storage-redis": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nest-lab/throttler-storage-redis/-/throttler-storage-redis-1.2.0.tgz",
+      "integrity": "sha512-tMkUyo68NCKTR+zILk+EC35SMYBtDPZY2mCj7ZaCietWGVTnuP4zwq9ERYfvU6kJv6h8teNZrC6MJCmY6/dljw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/throttler": ">=6.0.0",
+        "ioredis": ">=5.0.0",
+        "reflect-metadata": "^0.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/common": {
+          "optional": false
+        },
+        "@nestjs/core": {
+          "optional": false
+        },
+        "@nestjs/throttler": {
+          "optional": false
+        },
+        "ioredis": {
+          "optional": false
+        },
+        "reflect-metadata": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "11.0.16",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.16.tgz",
@@ -2764,9 +2797,9 @@
       }
     },
     "node_modules/@nestjs/microservices": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.16.tgz",
-      "integrity": "sha512-eG/ArIq0UJyR3i/GTYuApA4OZylhuLGacVaVT9mMxQgT7ZTpp5CZgOwLNdcUUdOS6qypK3waG1m2AC54xzdf0Q==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.19.tgz",
+      "integrity": "sha512-3Oja56ydTlSaui19/i7gYM0MMqz/w4UR2aqZeL4K8B+Fq0Ztg3zHb8et76atToJGpSCevJLEsoEMOMaGgzRwfg==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
@@ -14028,39 +14061,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nest-lab/throttler-storage-redis": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@nest-lab/throttler-storage-redis/-/throttler-storage-redis-1.2.0.tgz",
-      "integrity": "sha512-tMkUyo68NCKTR+zILk+EC35SMYBtDPZY2mCj7ZaCietWGVTnuP4zwq9ERYfvU6kJv6h8teNZrC6MJCmY6/dljw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-        "@nestjs/throttler": ">=6.0.0",
-        "ioredis": ">=5.0.0",
-        "reflect-metadata": "^0.2.1"
-      },
-      "peerDependenciesMeta": {
-        "@nestjs/common": {
-          "optional": false
-        },
-        "@nestjs/core": {
-          "optional": false
-        },
-        "@nestjs/throttler": {
-          "optional": false
-        },
-        "ioredis": {
-          "optional": false
-        },
-        "reflect-metadata": {
-          "optional": false
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,16 +31,16 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@nest-lab/throttler-storage-redis": "^1.2.0",
     "@nestjs/common": "^11.1.9",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.1.18",
     "@nestjs/jwt": "^11.0.1",
-    "@nestjs/microservices": "^11.1.16",
+    "@nestjs/microservices": "^11.1.19",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.9",
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.6",
-    "@nest-lab/throttler-storage-redis": "^1.2.0",
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^6.0.0",


### PR DESCRIPTION
## Summary
- Bump @nestjs/microservices from ^11.1.16 to ^11.1.19
- Fix HIGH severity CVE GHSA-hpwf-8g29-85qm: DoS via Recursive handleData in JsonSocket (TCP Transport)

## Verification
- npm audit: GHSA-hpwf-8g29-85qm cleared
- jest unit: 55 suites / 771 tests passing
- jest e2e (docker): 13 suites / 110 tests passing
- tsc --noEmit: clean
- eslint: 0 errors

Ticket: WHISPR-1320