### PR TITLE
[WHISPR-1347] feat(security): add helmet middleware for HTTP security headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "helmet": "^8.1.0",
         "ioredis": "^5.9.3",
         "jsonwebtoken": "^9.0.2",
         "libphonenumber-js": "^1.12.31",
@@ -8196,6 +8197,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "helmet": "^8.1.0",
     "ioredis": "^5.9.3",
     "jsonwebtoken": "^9.0.2",
     "libphonenumber-js": "^1.12.31",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { Logger, ValidationPipe, VersioningType } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { ConfigService } from '@nestjs/config';
+import helmet from 'helmet';
 import { AppModule } from './modules/app/app.module';
 import { createSwaggerDocumentation } from './swagger';
 import { LoggingInterceptor } from './interceptors';
@@ -24,6 +25,26 @@ async function bootstrap() {
 	const globalPrefix = 'auth';
 
 	app.setGlobalPrefix(globalPrefix);
+
+	// WHISPR-1347 : entêtes de sécurité HTTP (CSP, HSTS, X-Frame-Options, etc.)
+	// alignés sur user-service / media-service. CSP désactivée quand Swagger
+	// est servi en non-prod pour ne pas bloquer le SwaggerUI inline.
+	const swaggerEnabled = configService.get<string>('SWAGGER_ENABLED', 'true') !== 'false';
+	app.use(
+		helmet({
+			contentSecurityPolicy: swaggerEnabled
+				? {
+						directives: {
+							defaultSrc: ["'self'"],
+							scriptSrc: ["'self'", "'unsafe-inline'"],
+							styleSrc: ["'self'", "'unsafe-inline'", 'https:'],
+							imgSrc: ["'self'", 'data:'],
+						},
+					}
+				: undefined,
+			crossOriginEmbedderPolicy: swaggerEnabled ? false : undefined,
+		})
+	);
 
 	const corsOrigins = configService
 		.get<string>('CORS_ORIGINS', '')

--- a/test/helpers/create-test-app.ts
+++ b/test/helpers/create-test-app.ts
@@ -1,5 +1,6 @@
 import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common';
 import { TestingModule } from '@nestjs/testing';
+import helmet from 'helmet';
 
 /**
  * Creates a NestJS application for e2e testing with the same global
@@ -12,6 +13,22 @@ export async function createTestApp(moduleFixture: TestingModule): Promise<INest
 	const app = moduleFixture.createNestApplication();
 
 	app.setGlobalPrefix('auth');
+
+	// Aligne les tests sur le bootstrap prod : helmet doit être actif sinon
+	// le test des security headers (security-headers.e2e-spec.ts) serait faux.
+	app.use(
+		helmet({
+			contentSecurityPolicy: {
+				directives: {
+					defaultSrc: ["'self'"],
+					scriptSrc: ["'self'", "'unsafe-inline'"],
+					styleSrc: ["'self'", "'unsafe-inline'", 'https:'],
+					imgSrc: ["'self'", 'data:'],
+				},
+			},
+			crossOriginEmbedderPolicy: false,
+		})
+	);
 
 	app.enableVersioning({
 		type: VersioningType.URI,

--- a/test/security-headers.e2e-spec.ts
+++ b/test/security-headers.e2e-spec.ts
@@ -1,0 +1,86 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtAuthGuard } from '../src/modules/tokens/guards/jwt-auth.guard';
+import { CacheService } from '../src/modules/cache';
+import { PhoneAuthenticationService } from '../src/modules/phone-auth/services/phone-authentication.service';
+import { TokensService } from '../src/modules/tokens/services/tokens.service';
+import { JwtService } from '@nestjs/jwt';
+import { PhoneVerificationService } from '../src/modules/phone-verification/services/phone-verification/phone-verification.service';
+import { TwoFactorAuthenticationService } from '../src/modules/two-factor-authentication/services/two-factor-authentication.service';
+import { DevicesService } from '../src/modules/devices/services/devices.service';
+import { DataSource } from 'typeorm';
+import { createTestModule } from './helpers/create-test-module';
+import { createTestApp } from './helpers/create-test-app';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const request = require('supertest');
+
+// WHISPR-1347 : verifie que helmet pose bien les entetes de securite HTTP
+// (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+describe('Security headers (e2e)', () => {
+	let app: INestApplication;
+
+	beforeEach(async () => {
+		const moduleFixture = await createTestModule({
+			providers: [
+				{ provide: PhoneAuthenticationService, useValue: { register: jest.fn() } },
+				{ provide: PhoneVerificationService, useValue: { sendVerificationCode: jest.fn() } },
+				{ provide: TokensService, useValue: { generateToken: jest.fn() } },
+				{ provide: TwoFactorAuthenticationService, useValue: { generateSecret: jest.fn() } },
+				{ provide: DevicesService, useValue: { registerDevice: jest.fn() } },
+				{ provide: JwtService, useValue: { sign: jest.fn() } },
+				{
+					provide: DataSource,
+					useValue: { query: jest.fn().mockResolvedValue([{ '?column?': 1 }]) },
+				},
+				{
+					provide: CacheService,
+					useValue: {
+						get: jest.fn().mockResolvedValue('ok'),
+						set: jest.fn().mockResolvedValue(undefined),
+						del: jest.fn().mockResolvedValue(undefined),
+					},
+				},
+			],
+			guards: [{ guard: JwtAuthGuard, useValue: { canActivate: () => true } }],
+		});
+
+		app = await createTestApp(moduleFixture);
+	});
+
+	afterEach(async () => {
+		if (app) {
+			await app.close();
+		}
+	});
+
+	it('should set X-Content-Type-Options to nosniff', async () => {
+		const response = await request(app.getHttpServer()).get('/auth/v1/health/live').expect(200);
+
+		expect(response.headers['x-content-type-options']).toBe('nosniff');
+	});
+
+	it('should set X-Frame-Options to deny clickjacking', async () => {
+		const response = await request(app.getHttpServer()).get('/auth/v1/health/live').expect(200);
+
+		expect(response.headers['x-frame-options']).toBe('SAMEORIGIN');
+	});
+
+	it('should set a Referrer-Policy header', async () => {
+		const response = await request(app.getHttpServer()).get('/auth/v1/health/live').expect(200);
+
+		expect(response.headers['referrer-policy']).toBeDefined();
+	});
+
+	it('should set a Content-Security-Policy header', async () => {
+		const response = await request(app.getHttpServer()).get('/auth/v1/health/live').expect(200);
+
+		expect(response.headers['content-security-policy']).toBeDefined();
+		expect(response.headers['content-security-policy']).toContain("default-src 'self'");
+	});
+
+	it('should remove the X-Powered-By header to hide framework fingerprint', async () => {
+		const response = await request(app.getHttpServer()).get('/auth/v1/health/live').expect(200);
+
+		expect(response.headers['x-powered-by']).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- Ajoute `helmet()` au bootstrap d'auth-service pour poser les en-têtes HTTP de sécurité (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, etc.).
- Aligne le pattern sur user-service / media-service qui ont déjà helmet (cohérence inter-services).
- CSP désactivable quand SwaggerUI est servi (mêmes directives que user-service).
- Ajoute `helmet` aussi dans le helper de test e2e pour que la suite reflète le bootstrap prod.
- Nouveau test e2e `test/security-headers.e2e-spec.ts` qui valide la présence de X-Content-Type-Options, X-Frame-Options, Referrer-Policy, CSP et l'absence de X-Powered-By.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint "src/**/*.ts"` clean
- [x] Unit tests verts (774/774)
- [x] E2E `security-headers.e2e-spec.ts` vert (5/5)
- [x] E2E `app.e2e-spec.ts` toujours vert (pas de régression du helper)

Closes WHISPR-1347