### PR TITLE
[WHISPR-1372] fix(auth): masquer OTP/phone logs SMS (compliance/GDPR)

### DIFF
--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
@@ -20,6 +20,7 @@ import { UserAuthService } from '../../../common/services/user-auth.service';
 import { VerificationCodeGeneratorService } from '../verification-code-generator/verification-code-generator.service';
 import { PhoneNumberService } from '../phone-number/phone-number.service';
 import { RateLimitService } from '../rate-limit/rate-limit.service';
+import { maskPhone } from '../../../../utils/mask-phone.util';
 import type { VerificationRepository } from '../../repositories/verification.repository';
 import type { VerificationChannelStrategy } from '../../strategies/verification-channel.strategy';
 import { VerificationPurpose, VerificationCode, VerificationCreationResult } from '../../types';
@@ -236,27 +237,20 @@ export class PhoneVerificationService {
 		purpose: VerificationPurpose
 	): Promise<void> {
 		if (this.otpBypassCode) {
-			this.logger.warn(`[OTP BYPASS] Skipping SMS for ${phoneNumber} — bypass mode is active.`);
+			// WHISPR-1372: log du bypass sans phone E.164 en clair (compliance/RGPD).
+			this.logger.warn(
+				`[OTP BYPASS] Skipping SMS for ${maskPhone(phoneNumber)} - bypass mode is active.`
+			);
 			return;
 		}
 
 		try {
 			await this.verificationChannel.sendVerification(phoneNumber, code, purpose);
 		} catch (error) {
+			// WHISPR-1372: pas de log dupliquant l'OTP. sms.service est l'unique
+			// point qui logge l'envoi (avec phone masqué et OTP redacted).
 			if (process.env.NODE_ENV !== 'test') {
 				this.logger.error('Failed to send verification code:', error);
-				// ne jamais logguer le code OTP en clair, meme sur echec d'envoi: en prod
-				// les logs sont aggreges et indexes, c'est equivalent a une fuite credential.
-				// On garde une trace de l'echec sans le code.
-				if (process.env.NODE_ENV === 'development') {
-					this.logger.debug(
-						`Verification code for ${phoneNumber}: ${code} (development-only, redacted in other envs)`
-					);
-				} else {
-					this.logger.log(
-						`Verification code generation succeeded for ${phoneNumber} but SMS delivery failed (code redacted)`
-					);
-				}
 			}
 		}
 	}

--- a/src/modules/phone-verification/services/sms/sms.service.spec.ts
+++ b/src/modules/phone-verification/services/sms/sms.service.spec.ts
@@ -124,32 +124,76 @@ describe('SmsService', () => {
 		});
 	});
 
-	describe('buildMessage (via sendVerificationCode)', () => {
+	describe('buildMessage (via sendVerificationCode prod path)', () => {
+		// WHISPR-1372: les logs ne contiennent plus le message en clair (OTP redacted),
+		// donc on verifie le contenu du message via le body envoye a Twilio en prod.
+		const setupProdAndCaptureBody = async (): Promise<URLSearchParams> => {
+			service = await buildModule({
+				NODE_ENV: 'production',
+				TWILIO_ACCOUNT_SID: 'AC123',
+				TWILIO_AUTH_TOKEN: 'token',
+				TWILIO_FROM_NUMBER: '+1234567890',
+			});
+			let captured: URLSearchParams = new URLSearchParams();
+			jest.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+				captured = init?.body as URLSearchParams;
+				return { ok: true } as any;
+			});
+			return captured;
+		};
+
 		it('should use correct purpose text for registration', async () => {
-			service = await buildModule({ NODE_ENV: 'development' });
-			const logSpy = jest.spyOn(service['logger'], 'log');
+			await setupProdAndCaptureBody();
+			const fetchSpy = globalThis.fetch as jest.Mock;
 
 			await service.sendVerificationCode('+33612345678', '123456', 'registration');
 
-			expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('inscription'));
+			const body = fetchSpy.mock.calls[0][1].body as URLSearchParams;
+			expect(body.get('Body')).toContain('inscription');
 		});
 
 		it('should use correct purpose text for login', async () => {
+			await setupProdAndCaptureBody();
+			const fetchSpy = globalThis.fetch as jest.Mock;
+
+			await service.sendVerificationCode('+33612345678', '123456', 'login');
+
+			const body = fetchSpy.mock.calls[0][1].body as URLSearchParams;
+			expect(body.get('Body')).toContain('connexion');
+		});
+
+		it('should fall back to vérification for unknown purpose', async () => {
+			await setupProdAndCaptureBody();
+			const fetchSpy = globalThis.fetch as jest.Mock;
+
+			await service.sendVerificationCode('+33612345678', '123456', 'unknown');
+
+			const body = fetchSpy.mock.calls[0][1].body as URLSearchParams;
+			expect(body.get('Body')).toContain('vérification');
+		});
+	});
+
+	describe('phone masking in logs (WHISPR-1372)', () => {
+		it('should NEVER log the OTP code in dev mode', async () => {
+			service = await buildModule({ NODE_ENV: 'development' });
+			const logSpy = jest.spyOn(service['logger'], 'log');
+
+			await service.sendVerificationCode('+33612345678', '987654', 'registration');
+
+			const calls = logSpy.mock.calls.flat().join(' ');
+			expect(calls).not.toContain('987654');
+			expect(calls).toContain('[OTP redacted]');
+		});
+
+		it('should mask the phone number in dev logs', async () => {
 			service = await buildModule({ NODE_ENV: 'development' });
 			const logSpy = jest.spyOn(service['logger'], 'log');
 
 			await service.sendVerificationCode('+33612345678', '123456', 'login');
 
-			expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('connexion'));
-		});
-
-		it('should fall back to vérification for unknown purpose', async () => {
-			service = await buildModule({ NODE_ENV: 'development' });
-			const logSpy = jest.spyOn(service['logger'], 'log');
-
-			await service.sendVerificationCode('+33612345678', '123456', 'unknown');
-
-			expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('vérification'));
+			const calls = logSpy.mock.calls.flat().join(' ');
+			expect(calls).toContain('+33***5678');
+			expect(calls).not.toContain('+33612345678');
 		});
 	});
 });

--- a/src/modules/phone-verification/services/sms/sms.service.ts
+++ b/src/modules/phone-verification/services/sms/sms.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { maskPhone } from '../../../../utils/mask-phone.util';
 
 @Injectable()
 export class SmsService {
@@ -19,25 +20,29 @@ export class SmsService {
 	}
 
 	async sendVerificationCode(phoneNumber: string, code: string, purpose: string): Promise<void> {
+		// WHISPR-1372: on log uniquement le phone masqué et on redact l'OTP, peu importe
+		// l'env. C'est le seul point de log SMS du parcours OTP, les call-sites amont
+		// (phone-verification.service, sms-verification.strategy) ne loggent plus le code.
 		const message = this.buildMessage(code, purpose);
+		const maskedPhone = maskPhone(phoneNumber);
 
 		if (this.isDemoMode) {
 			this.logger.log(
-				`[DEMO MODE] SMS to ${phoneNumber}: the verification code is in the response payload.`
+				`[DEMO MODE] SMS to ${maskedPhone}: the verification code is in the response payload.`
 			);
 			return;
 		}
 
 		if (this.isDevelopment) {
-			this.logger.log(`[DEV MODE] SMS to ${phoneNumber}: ${message}`);
+			this.logger.log(`[DEV MODE] SMS to ${maskedPhone}: [OTP redacted]`);
 			return;
 		}
 
 		try {
 			await this.sendSms(phoneNumber, message);
-			this.logger.log(`SMS sent successfully to ${phoneNumber}`);
+			this.logger.log(`SMS sent successfully to ${maskedPhone}`);
 		} catch (error) {
-			this.logger.error(`Failed to send SMS to ${phoneNumber}:`, error);
+			this.logger.error(`Failed to send SMS to ${maskedPhone}:`, error);
 			throw new HttpException("Erreur lors de l'envoi du SMS", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -98,17 +103,19 @@ export class SmsService {
 		};
 
 		const message = messages[alertType];
+		// WHISPR-1372: meme regle pour les security alerts: pas de phone E.164 en clair.
+		const maskedPhone = maskPhone(phoneNumber);
 
 		if (this.isDevelopment) {
-			this.logger.log(`[DEV MODE] Security alert to ${phoneNumber}: ${message}`);
+			this.logger.log(`[DEV MODE] Security alert to ${maskedPhone}: ${message}`);
 			return;
 		}
 
 		try {
 			await this.sendSms(phoneNumber, message);
-			this.logger.log(`Security alert sent to ${phoneNumber}`);
+			this.logger.log(`Security alert sent to ${maskedPhone}`);
 		} catch (error) {
-			this.logger.error(`Failed to send security alert to ${phoneNumber}:`, error);
+			this.logger.error(`Failed to send security alert to ${maskedPhone}:`, error);
 			// Don't throw here as security alerts are not critical for user flow
 		}
 	}

--- a/src/modules/phone-verification/strategies/sms-verification.strategy.ts
+++ b/src/modules/phone-verification/strategies/sms-verification.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { VerificationChannelStrategy } from './verification-channel.strategy';
 import { SmsService } from '../services/sms/sms.service';
 import { VerificationPurpose } from '../types/verification-purpose.type';
+import { maskPhone } from '../../../utils/mask-phone.util';
 
 /**
  * SMS-based implementation of the VerificationChannelStrategy.
@@ -27,20 +28,10 @@ export class SmsVerificationStrategy implements VerificationChannelStrategy {
 		try {
 			await this.smsService.sendVerificationCode(recipient, code, purpose);
 		} catch (error) {
-			// Log the error but don't fail - allow the verification process to continue
+			// WHISPR-1372: phone masqué et OTP jamais loggué (compliance/RGPD).
+			// Le code OTP n'apparait nulle part dans les logs, peu importe l'env.
 			if (process.env.NODE_ENV !== 'test') {
-				this.logger.error(`Failed to send SMS to ${recipient}:`, error);
-				// ne pas exposer le code en clair dans les logs prod/staging.
-				// uniquement en development local pour faciliter le debug manuel.
-				if (process.env.NODE_ENV === 'development') {
-					this.logger.debug(
-						`Verification code for ${recipient}: ${code} (development-only, redacted in other envs)`
-					);
-				} else {
-					this.logger.log(
-						`Verification code generation succeeded for ${recipient} but SMS delivery failed (code redacted)`
-					);
-				}
+				this.logger.error(`Failed to send SMS to ${maskPhone(recipient)}:`, error);
 			}
 			// Re-throw in production to handle properly
 			if (process.env.NODE_ENV === 'production') {

--- a/src/utils/mask-phone.util.spec.ts
+++ b/src/utils/mask-phone.util.spec.ts
@@ -1,0 +1,33 @@
+import { maskPhone } from './mask-phone.util';
+
+describe('maskPhone', () => {
+	it('masks a standard French E.164 number keeping prefix and last 4 digits', () => {
+		expect(maskPhone('+33612345678')).toBe('+33***5678');
+	});
+
+	it('masks a US E.164 number', () => {
+		expect(maskPhone('+14155551234')).toBe('+14***1234');
+	});
+
+	it('returns <empty> for empty string', () => {
+		expect(maskPhone('')).toBe('<empty>');
+	});
+
+	it('returns <empty> for null', () => {
+		expect(maskPhone(null)).toBe('<empty>');
+	});
+
+	it('returns <empty> for undefined', () => {
+		expect(maskPhone(undefined)).toBe('<empty>');
+	});
+
+	it('returns *** for short input below masking threshold', () => {
+		expect(maskPhone('+33612')).toBe('***');
+	});
+
+	it('does not leak middle digits of a long number', () => {
+		const masked = maskPhone('+33698765432');
+		expect(masked).not.toContain('98765');
+		expect(masked).not.toContain('9876');
+	});
+});

--- a/src/utils/mask-phone.util.ts
+++ b/src/utils/mask-phone.util.ts
@@ -1,0 +1,12 @@
+// WHISPR-1372: masque les numéros E.164 avant tout log pour respecter le RGPD.
+// On garde le préfixe (3 premiers chars, ex: "+33") et les 4 derniers chiffres
+// pour rester traçable côté ops sans exposer le numéro complet.
+export function maskPhone(phone: string | null | undefined): string {
+	if (!phone) {
+		return '<empty>';
+	}
+	if (phone.length <= 7) {
+		return '***';
+	}
+	return `${phone.slice(0, 3)}***${phone.slice(-4)}`;
+}


### PR DESCRIPTION
## Summary

- Helper `maskPhone()` (`src/utils/mask-phone.util.ts`) qui retourne `+33***5678` pour un E.164 standard.
- `sms.service.ts` est l'unique point de log SMS du parcours OTP. Le code OTP est redacted (`[OTP redacted]`) en dev mode et n'apparait nulle part dans les logs. Le phone est masque sur tous les logs (success, error, dev, demo, security alerts).
- `phone-verification.service.ts` : retire le `logger.debug('Verification code for ${phone}: ${code}')` qui leakait l'OTP en dev. Masque le phone dans le log `[OTP BYPASS]`.
- `sms-verification.strategy.ts` : retire la branche `logger.debug` qui leakait aussi l'OTP. Masque le phone dans le log d'erreur.

## Pourquoi

3 surfaces logaient l'OTP en clair conditionne par `NODE_ENV` ou `isDevelopment` : un drift de config en preprod/prod = fuite credential dans Loki/ELK. On centralise et on redact.

Le bypass `OTP_BYPASS_CODE=123456` continue de marcher (le warn `[OTP BYPASS]` reste, juste avec phone masque). Le banner DEMO n'est pas touche.

## Test plan

- [x] `mask-phone.util.spec.ts` : 7 tests (E.164 FR/US, empty/null/undefined, court, no-leak du milieu).
- [x] `sms.service.spec.ts` : 2 nouveaux tests qui assertent que le code OTP n'apparait jamais dans les logs et que le phone est masque.
- [x] `sms.service.spec.ts buildMessage` : reecrit pour asserter sur le body Twilio (production path observable) plutot que sur le contenu du log dev.
- [x] `npm test` : 783/783 tests verts.
- [x] Lint + prettier clean.

Closes WHISPR-1372