### PR TITLE
[WHISPR-1379] chore(observability): TypeORM slow query log

### DIFF
--- a/src/modules/app/typeorm.ts
+++ b/src/modules/app/typeorm.ts
@@ -78,6 +78,8 @@ function getDataSourceOptions(configService: ConfigService): DataSourceOptions {
 		// Indicates if database schema should be auto created on every application launch.
 		// Be careful with this option and don't use this in production - otherwise you can lose production data.
 		synchronize: configService.get('DB_SYNCHRONIZE', 'false') === 'true',
+		// Log queries qui prennent plus de 500ms via le logger NestJS pour detecter les slow queries en prod.
+		maxQueryExecutionTime: 500,
 	};
 }
 


### PR DESCRIPTION
## Summary
- Ajout de `maxQueryExecutionTime: 500` dans la config TypeORM (`src/modules/app/typeorm.ts`).
- TypeORM logge automatiquement via le logger NestJS toute query qui depasse 500ms, ce qui rend visibles les slow queries en preprod/prod.

## Test plan
- [x] `npm test` 783/783 green
- [x] Lint clean
- [x] Diff = 2 lignes ajoutees, aucune autre modif

Closes WHISPR-1379