### PR TITLE
[WHISPR-1386] fix(2fa): rate limit anti brute-force TOTP

### DIFF
--- a/src/modules/two-factor-authentication/controllers/two-factor-authentication.controller.ts
+++ b/src/modules/two-factor-authentication/controllers/two-factor-authentication.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Request, Post, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import {
 	TwoFactorBackupCodesResponseDto,
 	TwoFactorDisableResponseDto,
@@ -24,6 +25,11 @@ import {
 } from './two-factor-authentication.controller.swagger';
 
 @ApiTags('Auth - Two Factor Authentication (2FA)')
+// rate limit strict pour eviter brute-force TOTP 6 chiffres (10^6 codes)
+// throttler global LONG (100/min) ne suffit pas - un JWT vole permettrait
+// 6000 tentatives/h dans la fenetre TOTP de 30s
+// override par methode possible (verify est plus strict, cf ci-dessous)
+@Throttle({ default: { ttl: 60_000, limit: 5 } })
 @Controller('2fa')
 export class TwoFactorAuthenticationController {
 	constructor(private readonly twoFactorService: TwoFactorAuthenticationService) {}
@@ -48,6 +54,8 @@ export class TwoFactorAuthenticationController {
 	}
 
 	@Post('verify')
+	// palier plus strict sur verify : c'est l'endpoint cible pour brute-force TOTP
+	@Throttle({ default: { ttl: 60_000, limit: 3 } })
 	@UseGuards(JwtAuthGuard)
 	@HttpCode(HttpStatus.OK)
 	@ApiVerifyTwoFactorEndpoint()


### PR DESCRIPTION
## Contexte

Bug HIGH securite : tous les endpoints du `TwoFactorAuthenticationController` (`/2fa/setup`, `/2fa/enable`, `/2fa/verify`, `/2fa/disable`, `/2fa/backup-codes`, etc.) ne sont protegees que par le throttler global tier LONG (100 req/60s).

Vecteur d'attaque : avec un JWT valide (vol de token, etape pre-2FA), un attaquant peut tenter 6000 codes TOTP/h - largement suffisant pour casser un code 6 chiffres dans la fenetre 30s standard.

Pattern correct deja en place sur `PhoneAuthenticationController` (cf WHISPR-996/997) : `@Throttle({ default: { ttl: 60000, limit: 10 } })` au niveau classe.

## Changements

- `@Throttle({ default: { ttl: 60_000, limit: 5 } })` au niveau classe `TwoFactorAuthenticationController` (5 req/min/IP).
- Override plus strict sur `POST /2fa/verify` : 3 req/min/IP (cible principale du brute-force TOTP).
- Commentaires FR expliquant le pourquoi du palier strict.

## Behavior change

Avant : 100 attempts/min (throttler global LONG) sur tous les endpoints 2FA.
Apres : 5 attempts/min sur le controller, 3 attempts/min specifiquement sur `verify`.

Impact UX legitime nul : un user qui setup/verify son 2FA tape ~1 code par tentative, jamais 5+ en 60s.

## Test plan

- [x] Unit tests verts (51/51 sur le module 2FA, 783/783 sur l'ensemble auth-service)
- [x] Lint + prettier clean
- [ ] E2E throttle non ajoute - le throttler est deja teste sur `phone-authentication` avec le meme pattern, et la suite e2e du throttler est volumineuse a faire booter
- [ ] Verification preprod : 6 POST `/2fa/verify` consecutifs renvoient 429 sur la 4eme

Closes WHISPR-1386