### PR TITLE
[WHISPR-1393] fix(auth): OTP resend invalide ancien verificationId

### DIFF
--- a/src/modules/phone-verification/repositories/cache-verification.repository.spec.ts
+++ b/src/modules/phone-verification/repositories/cache-verification.repository.spec.ts
@@ -54,6 +54,41 @@ describe('CacheVerificationRepository', () => {
 				901
 			);
 		});
+
+		// WHISPR-1393
+		it('should also write the reverse phone-purpose index for resend invalidation', async () => {
+			mockCacheService.set.mockResolvedValue(undefined);
+
+			await repository.save('verification-id', verificationData, 900000);
+
+			expect(mockCacheService.set).toHaveBeenCalledWith(
+				'verification:phone-purpose:+33612345678:registration',
+				'verification-id',
+				900
+			);
+		});
+	});
+
+	// WHISPR-1393
+	describe('findByPhoneAndPurpose', () => {
+		it('should return the active verificationId when reverse index is present', async () => {
+			mockCacheService.get.mockResolvedValue('active-id');
+
+			const result = await repository.findByPhoneAndPurpose('+33612345678', 'registration');
+
+			expect(result).toEqual({ verificationId: 'active-id' });
+			expect(mockCacheService.get).toHaveBeenCalledWith(
+				'verification:phone-purpose:+33612345678:registration'
+			);
+		});
+
+		it('should return null when no reverse index exists', async () => {
+			mockCacheService.get.mockResolvedValue(null);
+
+			const result = await repository.findByPhoneAndPurpose('+33612345678', 'login');
+
+			expect(result).toBeNull();
+		});
 	});
 
 	describe('findById', () => {
@@ -90,12 +125,27 @@ describe('CacheVerificationRepository', () => {
 	});
 
 	describe('delete', () => {
-		it('should delete the verification key', async () => {
+		it('should delete the verification key and clear the reverse index', async () => {
+			mockCacheService.get.mockResolvedValue(verificationData);
 			mockCacheService.del.mockResolvedValue(undefined);
 
 			await repository.delete('verification-id');
 
 			expect(mockCacheService.del).toHaveBeenCalledWith('verification:verification-id');
+			expect(mockCacheService.del).toHaveBeenCalledWith(
+				'verification:phone-purpose:+33612345678:registration'
+			);
+		});
+
+		// WHISPR-1393: protection si l'enregistrement a déjà expiré
+		it('should still delete the main key when verification record is missing', async () => {
+			mockCacheService.get.mockResolvedValue(null);
+			mockCacheService.del.mockResolvedValue(undefined);
+
+			await repository.delete('verification-id');
+
+			expect(mockCacheService.del).toHaveBeenCalledWith('verification:verification-id');
+			expect(mockCacheService.del).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/src/modules/phone-verification/repositories/cache-verification.repository.ts
+++ b/src/modules/phone-verification/repositories/cache-verification.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { CacheService } from '../../cache/cache.service';
 import { VerificationRepository } from './verification.repository';
 import { VerificationCode } from '../types/verification-code.interface';
+import { VerificationPurpose } from '../types/verification-purpose.type';
 
 /**
  * Cache-based implementation of the VerificationRepository.
@@ -10,6 +11,9 @@ import { VerificationCode } from '../types/verification-code.interface';
 @Injectable()
 export class CacheVerificationRepository implements VerificationRepository {
 	private readonly KEY_PREFIX = 'verification:';
+	// WHISPR-1393: index inverse (phone, purpose) -> verificationId pour invalider
+	// l'ancien OTP au resend (anti-replay).
+	private readonly REVERSE_KEY_PREFIX = 'verification:phone-purpose:';
 
 	constructor(private readonly cacheManager: CacheService) {}
 
@@ -23,6 +27,9 @@ export class CacheVerificationRepository implements VerificationRepository {
 		const key = this.getKey(id);
 		const ttlInSeconds = Math.ceil(ttl / 1000);
 		await this.cacheManager.set(key, data, ttlInSeconds);
+		// maintenir l'index inverse pour permettre l'invalidation au resend
+		const reverseKey = this.getReverseKey(data.phoneNumber, data.purpose);
+		await this.cacheManager.set(reverseKey, id, ttlInSeconds);
 	}
 
 	/**
@@ -35,6 +42,22 @@ export class CacheVerificationRepository implements VerificationRepository {
 		const data = await this.cacheManager.get<VerificationCode>(key);
 
 		return data;
+	}
+
+	/**
+	 * WHISPR-1393: lookup d'un verificationId existant pour (phone, purpose).
+	 * Utilisé au resend pour invalider l'ancien OTP avant d'en créer un nouveau.
+	 */
+	public async findByPhoneAndPurpose(
+		phoneNumber: string,
+		purpose: VerificationPurpose
+	): Promise<{ verificationId: string } | null> {
+		const reverseKey = this.getReverseKey(phoneNumber, purpose);
+		const verificationId = await this.cacheManager.get<string>(reverseKey);
+		if (!verificationId) {
+			return null;
+		}
+		return { verificationId };
 	}
 
 	/**
@@ -53,7 +76,13 @@ export class CacheVerificationRepository implements VerificationRepository {
 	 */
 	public async delete(id: string): Promise<void> {
 		const key = this.getKey(id);
+		// récupère le record avant suppression pour nettoyer l'index inverse
+		const data = await this.cacheManager.get<VerificationCode>(key);
 		await this.cacheManager.del(key);
+		if (data) {
+			const reverseKey = this.getReverseKey(data.phoneNumber, data.purpose);
+			await this.cacheManager.del(reverseKey);
+		}
 	}
 
 	/**
@@ -63,5 +92,9 @@ export class CacheVerificationRepository implements VerificationRepository {
 	 */
 	private getKey(id: string): string {
 		return `${this.KEY_PREFIX}${id}`;
+	}
+
+	private getReverseKey(phoneNumber: string, purpose: VerificationPurpose): string {
+		return `${this.REVERSE_KEY_PREFIX}${phoneNumber}:${purpose}`;
 	}
 }

--- a/src/modules/phone-verification/repositories/verification.repository.ts
+++ b/src/modules/phone-verification/repositories/verification.repository.ts
@@ -1,4 +1,5 @@
 import { VerificationCode } from '../types/verification-code.interface';
+import { VerificationPurpose } from '../types/verification-purpose.type';
 
 /**
  * Repository interface for verification operations.
@@ -21,6 +22,16 @@ export interface VerificationRepository {
 	 * @returns The verification data if found, null otherwise
 	 */
 	findById(id: string): Promise<VerificationCode | null>;
+
+	/**
+	 * WHISPR-1393: lookup inverse pour invalidation au resend.
+	 * Retourne l'identifiant du verification record actif pour (phone, purpose),
+	 * ou null s'il n'y en a pas.
+	 */
+	findByPhoneAndPurpose(
+		phoneNumber: string,
+		purpose: VerificationPurpose
+	): Promise<{ verificationId: string } | null>;
 
 	/**
 	 * Updates an existing verification record.

--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.spec.ts
@@ -14,6 +14,7 @@ describe('PhoneVerificationService', () => {
 	const mockVerificationRepo = {
 		save: jest.fn(),
 		findById: jest.fn(),
+		findByPhoneAndPurpose: jest.fn().mockResolvedValue(null),
 		update: jest.fn(),
 		delete: jest.fn(),
 	};
@@ -192,6 +193,28 @@ describe('PhoneVerificationService', () => {
 			await expect(
 				service.requestRegistrationVerification({ phoneNumber: '+33612345678' }, '203.0.113.42')
 			).rejects.toThrow(HttpException);
+		});
+
+		// WHISPR-1393: anti-replay au resend
+		it('should invalidate the previous verificationId when one already exists for the phone+purpose', async () => {
+			mockUserAuthService.findByPhoneNumber.mockResolvedValue(null);
+			mockRateLimitService.checkLimit.mockResolvedValue(undefined);
+			mockRateLimitService.increment.mockResolvedValue(undefined);
+			mockVerificationRepo.findByPhoneAndPurpose.mockResolvedValueOnce({
+				verificationId: 'old-verification-id',
+			});
+			mockVerificationRepo.delete.mockResolvedValue(undefined);
+			mockVerificationRepo.save.mockResolvedValue(undefined);
+			mockVerificationChannel.sendVerification.mockResolvedValue(undefined);
+
+			await service.requestRegistrationVerification({ phoneNumber: '+33612345678' });
+
+			expect(mockVerificationRepo.findByPhoneAndPurpose).toHaveBeenCalledWith(
+				'+33612345678',
+				'registration'
+			);
+			expect(mockVerificationRepo.delete).toHaveBeenCalledWith('old-verification-id');
+			expect(mockVerificationRepo.save).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
+++ b/src/modules/phone-verification/services/phone-verification/phone-verification.service.ts
@@ -124,6 +124,13 @@ export class PhoneVerificationService {
 			deviceId
 		);
 
+		// WHISPR-1393: au resend, invalider l'ancien verificationId pour éviter
+		// que deux OTP simultanés restent valides en parallèle (anti-replay).
+		const previous = await this.verificationRepo.findByPhoneAndPurpose(normalizedPhone, purpose);
+		if (previous) {
+			await this.verificationRepo.delete(previous.verificationId);
+		}
+
 		await this.verificationRepo.save(verificationId, verificationData, this.VERIFICATION_TTL_MS);
 
 		await this.incrementRateLimit(normalizedPhone);


### PR DESCRIPTION
## Summary

Avant ce fix, `requestVerification` enregistrait un nouveau `verificationId` sans supprimer l'ancien pour le couple `(phoneNumber, purpose)`. Les deux OTP restaient valides en parallèle dans Redis jusqu'au TTL (15 min), ouvrant une fenêtre anti-replay : un attaquant qui avait intercepté le 1er SMS pouvait l'utiliser même après que l'utilisateur ait demandé un resend.

## Fix

- Index inverse Redis `verification:phone-purpose:{phone}:{purpose} -> verificationId` maintenu par `save` et nettoyé par `delete`.
- Nouvelle méthode `findByPhoneAndPurpose(phone, purpose)` sur `VerificationRepository`.
- `requestVerification` lookup l'ancien id avant le `save` et le `delete` s'il existe.

## Test plan

- [x] Unit `cache-verification.repository.spec.ts` : save écrit l'index inverse, findByPhoneAndPurpose, delete clean les deux clés.
- [x] Unit `phone-verification.service.spec.ts` : resend appelle `delete(oldId)` quand l'index inverse existe.
- [x] `npm test` 788/788 verts.

Closes WHISPR-1393.