### PR TITLE
[WHISPR-1397] fix(security): identity key rotation audit

### DIFF
--- a/src/modules/signal/repositories/identity-key.repository.spec.ts
+++ b/src/modules/signal/repositories/identity-key.repository.spec.ts
@@ -1,8 +1,10 @@
+import { Logger } from '@nestjs/common';
 import { IdentityKeyRepository } from './identity-key.repository';
 import { IdentityKey } from '../entities/identity-key.entity';
 
 describe('IdentityKeyRepository', () => {
 	let repository: IdentityKeyRepository;
+	let warnSpy: jest.SpyInstance;
 
 	const mockManager = {
 		connection: {
@@ -26,6 +28,11 @@ describe('IdentityKeyRepository', () => {
 		jest.spyOn(repository, 'save').mockImplementation(mockManager.save);
 		jest.spyOn(repository, 'create').mockImplementation(mockManager.create);
 		jest.spyOn(repository, 'delete').mockImplementation(mockManager.delete);
+		warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
 	});
 
 	describe('findByUserIdAndDeviceId', () => {
@@ -51,12 +58,12 @@ describe('IdentityKeyRepository', () => {
 	});
 
 	describe('upsertIdentityKey', () => {
-		it('should update existing key when it exists', async () => {
+		it('should log warn and update existing key on rotation', async () => {
 			const existing = {
 				userId: 'user-1',
 				deviceId: 'device-1',
 				publicKey: 'old-key',
-				updatedAt: new Date('2024-01-01'),
+				updatedAt: new Date('2024-01-01T00:00:00.000Z'),
 			} as IdentityKey;
 			const updated = { ...existing, publicKey: 'new-key' } as IdentityKey;
 			mockManager.findOne.mockResolvedValue(existing);
@@ -66,9 +73,33 @@ describe('IdentityKeyRepository', () => {
 
 			expect(result.publicKey).toBe('new-key');
 			expect(repository.save).toHaveBeenCalledWith(expect.objectContaining({ publicKey: 'new-key' }));
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			const warnMsg = warnSpy.mock.calls[0][0];
+			expect(warnMsg).toContain('Identity key rotated');
+			expect(warnMsg).toContain('user=user-1');
+			expect(warnMsg).toContain('device=device-1');
+			expect(warnMsg).toContain('oldFingerprint=');
+			expect(warnMsg).toContain('newFingerprint=');
+			expect(warnMsg).toContain('previousUpdatedAt=2024-01-01T00:00:00.000Z');
 		});
 
-		it('should create a new key when it does not exist', async () => {
+		it('should be a no-op when the key is identical (idempotent)', async () => {
+			const existing = {
+				userId: 'user-1',
+				deviceId: 'device-1',
+				publicKey: 'same-key',
+				updatedAt: new Date('2024-01-01'),
+			} as IdentityKey;
+			mockManager.findOne.mockResolvedValue(existing);
+
+			const result = await repository.upsertIdentityKey('user-1', 'device-1', 'same-key');
+
+			expect(result).toBe(existing);
+			expect(repository.save).not.toHaveBeenCalled();
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
+		it('should create a new key without warn when it does not exist', async () => {
 			const newKey = { userId: 'user-1', deviceId: 'device-1', publicKey: 'new-key' } as IdentityKey;
 			mockManager.findOne.mockResolvedValue(null);
 			mockManager.create.mockReturnValue(newKey);
@@ -83,6 +114,7 @@ describe('IdentityKeyRepository', () => {
 				publicKey: 'new-key',
 			});
 			expect(repository.save).toHaveBeenCalledWith(newKey);
+			expect(warnSpy).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/modules/signal/repositories/identity-key.repository.ts
+++ b/src/modules/signal/repositories/identity-key.repository.ts
@@ -1,7 +1,11 @@
+import { Logger } from '@nestjs/common';
+import { createHash } from 'crypto';
 import { Repository, EntityManager, EntityTarget, QueryRunner } from 'typeorm';
 import { IdentityKey } from '../entities/identity-key.entity';
 
 export class IdentityKeyRepository extends Repository<IdentityKey> {
+	private readonly logger = new Logger(IdentityKeyRepository.name);
+
 	constructor(target: EntityTarget<IdentityKey>, manager: EntityManager, queryRunner?: QueryRunner) {
 		super(target, manager, queryRunner);
 	}
@@ -16,12 +20,29 @@ export class IdentityKeyRepository extends Repository<IdentityKey> {
 	}
 
 	/**
-	 * Create or update an identity key for a user and device
+	 * Create or update an identity key for a user and device.
+	 *
+	 * Une rotation (publicKey existante remplacee par une nouvelle) emet un log
+	 * audit warn pour permettre la detection MITM cote mobile (TOFU safety
+	 * number). Un re-set idempotent avec la meme cle reste un no-op silencieux.
 	 */
 	async upsertIdentityKey(userId: string, deviceId: string, publicKey: string): Promise<IdentityKey> {
 		const existingKey = await this.findByUserIdAndDeviceId(userId, deviceId);
 
 		if (existingKey) {
+			if (existingKey.publicKey === publicKey) {
+				return existingKey;
+			}
+
+			// rotation detectee : on log les fingerprints pour permettre aux peers
+			// de detecter un changement d'identity key (futur subscriber mobile)
+			this.logger.warn(
+				`Identity key rotated for user=${userId} device=${deviceId} ` +
+					`oldFingerprint=${this.fingerprint(existingKey.publicKey)} ` +
+					`newFingerprint=${this.fingerprint(publicKey)} ` +
+					`previousUpdatedAt=${existingKey.updatedAt?.toISOString() ?? 'unknown'}`
+			);
+
 			existingKey.publicKey = publicKey;
 			existingKey.updatedAt = new Date();
 			return this.save(existingKey);
@@ -34,6 +55,14 @@ export class IdentityKeyRepository extends Repository<IdentityKey> {
 		});
 
 		return this.save(newKey);
+	}
+
+	/**
+	 * Fingerprint court (16 hex chars de SHA256) d'une cle publique base64.
+	 * Utilise pour les logs audit, evite de log la cle complete.
+	 */
+	private fingerprint(publicKey: string): string {
+		return createHash('sha256').update(publicKey).digest('hex').slice(0, 16);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Detection rotation vs idempotent set dans `IdentityKeyRepository.upsertIdentityKey`
- Log audit warn (user, device, fingerprints SHA256, previousUpdatedAt) sur rotation reelle
- No-op silencieux quand la nouvelle cle est identique (idempotence preservee)
- Helper `fingerprint` interne (16 hex chars) pour eviter de log la cle complete

## Why

Avant ce fix, `upsertIdentityKey` overwrite silencieusement la cle d'identite Signal d'un user
sans aucun event ni log. Quand un user re-register sur un nouveau device, les peers fetchent
la nouvelle bundle et ne peuvent pas detecter le changement -> MITM ou account takeover
indetectable cote mobile.

Le log warn permettra a un futur subscriber mobile (ou a un audit log puller) de remonter
l'event vers un warning "Safety number changed" UI cote app.

## Test plan

- [x] Unit test rotation -> log warn avec fingerprints
- [x] Unit test idempotent set -> no-op, pas de save, pas de warn
- [x] Unit test premier set -> create, pas de warn
- [x] Suite signal complete (153 tests) verte
- [x] `tsc --noEmit` clean

Closes WHISPR-1397