### PR TITLE
[WHISPR-1401] fix(auth): absolute cap 90j refresh token

### DIFF
--- a/src/modules/tokens/services/tokens.service.spec.ts
+++ b/src/modules/tokens/services/tokens.service.spec.ts
@@ -379,6 +379,80 @@ describe('TokensService', () => {
 				'ERROR_DEVICE_FINGERPRINT_MISMATCH'
 			);
 		});
+
+		// WHISPR-1401 : cap absolu 90j sur la session pour eviter session zombie
+		// quand un refresh token vole reste valide indefiniment via refresh roulants.
+		it('should propagate firstIssuedAt from old refresh to the new pair', async () => {
+			const tokenId = 'token-id';
+			const firstIssuedAt = Date.now() - 30 * 24 * 60 * 60 * 1000; // 30j old
+			const fp = 'fpfpfpfpfpfp';
+
+			jwtService.verify.mockReturnValue({ type: 'refresh', tokenId, firstIssuedAt });
+			cacheService.getReliable.mockResolvedValue({
+				userId: 'u',
+				deviceId: 'd',
+				fingerprint: fp,
+				firstIssuedAt,
+			});
+			cacheService.del.mockResolvedValue(undefined);
+			cacheService.set.mockResolvedValue(undefined);
+			jwtService.sign.mockReturnValueOnce('new-access').mockReturnValueOnce('new-refresh');
+			jest.spyOn(service as any, 'generateDeviceFingerprint').mockReturnValue(fp);
+
+			await service.refreshAccessToken('some-token', mockFingerprint);
+
+			// nouveau refresh payload doit contenir le firstIssuedAt original (pas reset)
+			const refreshSignCall = jwtService.sign.mock.calls[1][0] as Record<string, unknown>;
+			expect(refreshSignCall.firstIssuedAt).toBe(firstIssuedAt);
+
+			// stored data Redis aussi doit contenir le firstIssuedAt original
+			const cachedPayload = cacheService.set.mock.calls[0][1] as Record<string, unknown>;
+			expect(cachedPayload.firstIssuedAt).toBe(firstIssuedAt);
+		});
+
+		it('should throw ERROR_SESSION_EXPIRED_ABSOLUTE when session is older than 90 days', async () => {
+			const tokenId = 'token-id';
+			const firstIssuedAt = Date.now() - 91 * 24 * 60 * 60 * 1000; // 91j old, > cap 90j
+			const fp = 'fpfpfpfpfpfp';
+
+			jwtService.verify.mockReturnValue({ type: 'refresh', tokenId, firstIssuedAt });
+			cacheService.getReliable.mockResolvedValue({
+				userId: 'u',
+				deviceId: 'd',
+				fingerprint: fp,
+				firstIssuedAt,
+			});
+			cacheService.del.mockResolvedValue(undefined);
+			jest.spyOn(service as any, 'generateDeviceFingerprint').mockReturnValue(fp);
+
+			await expect(service.refreshAccessToken('some-token', mockFingerprint)).rejects.toThrow(
+				'ERROR_SESSION_EXPIRED_ABSOLUTE'
+			);
+			// le refresh token doit etre revoke avant le throw
+			expect(cacheService.del).toHaveBeenCalledWith(`refresh_token:${tokenId}`);
+		});
+
+		it('should seed firstIssuedAt to Date.now() for legacy sessions without it', async () => {
+			const tokenId = 'token-id';
+			const fp = 'fpfpfpfpfpfp';
+
+			// payload signe et stored data SANS firstIssuedAt (ancienne session)
+			jwtService.verify.mockReturnValue({ type: 'refresh', tokenId });
+			cacheService.getReliable.mockResolvedValue({ userId: 'u', deviceId: 'd', fingerprint: fp });
+			cacheService.del.mockResolvedValue(undefined);
+			cacheService.set.mockResolvedValue(undefined);
+			jwtService.sign.mockReturnValueOnce('new-access').mockReturnValueOnce('new-refresh');
+			jest.spyOn(service as any, 'generateDeviceFingerprint').mockReturnValue(fp);
+
+			const before = Date.now();
+			await service.refreshAccessToken('some-token', mockFingerprint);
+			const after = Date.now();
+
+			// le nouveau payload doit avoir un firstIssuedAt seede a now (entre before/after)
+			const refreshSignCall = jwtService.sign.mock.calls[1][0] as { firstIssuedAt: number };
+			expect(refreshSignCall.firstIssuedAt).toBeGreaterThanOrEqual(before);
+			expect(refreshSignCall.firstIssuedAt).toBeLessThanOrEqual(after);
+		});
 	});
 
 	describe('revokeToken', () => {

--- a/src/modules/tokens/services/tokens.service.ts
+++ b/src/modules/tokens/services/tokens.service.ts
@@ -12,6 +12,10 @@ import { JwksService } from '../../jwks/jwks.service';
 export class TokensService {
 	private readonly ACCESS_TOKEN_TTL = 60 * 60;
 	private readonly REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60;
+	// cap absolu pour eviter session zombie sur refresh token vole : meme
+	// si l'utilisateur reste actif, on borne la duree totale d'une session
+	// a partir du login initial (firstIssuedAt) — au-dela, re-auth obligatoire.
+	private readonly ABSOLUTE_SESSION_CAP_MS = 90 * 24 * 60 * 60 * 1000;
 	// Court-vivant — WHISPR-1214. Le token transite dans la query string
 	// Phoenix Channels, donc reverse-proxies, HAR exports et Sentry
 	// breadcrumbs le capturent ; 60 s borne le préjudice d'une fuite.
@@ -36,11 +40,15 @@ export class TokensService {
 	async generateTokenPair(
 		userId: string,
 		deviceId: string,
-		fingerprint: DeviceFingerprint
+		fingerprint: DeviceFingerprint,
+		firstIssuedAt?: number
 	): Promise<TokenPair> {
 		const deviceFingerprint = this.generateDeviceFingerprint(fingerprint);
 		const accessTokenId = uuidv4();
 		const refreshTokenId = uuidv4();
+		// firstIssuedAt = timestamp du login initial (ms epoch). Propage au refresh
+		// pour enforcer le cap absolu independamment du nombre de refresh.
+		const sessionFirstIssuedAt = firstIssuedAt ?? Date.now();
 
 		const accessTokenPayload: JwtPayload = {
 			sub: userId,
@@ -59,6 +67,7 @@ export class TokensService {
 			type: 'refresh',
 			iat: Math.floor(Date.now() / 1000),
 			exp: Math.floor(Date.now() / 1000) + this.REFRESH_TOKEN_TTL,
+			firstIssuedAt: sessionFirstIssuedAt,
 		};
 
 		const kid = this.jwksService.getKid();
@@ -75,7 +84,7 @@ export class TokensService {
 
 		await this.cacheService.set(
 			`refresh_token:${refreshTokenId}`,
-			{ userId, deviceId, fingerprint: deviceFingerprint },
+			{ userId, deviceId, fingerprint: deviceFingerprint, firstIssuedAt: sessionFirstIssuedAt },
 			this.REFRESH_TOKEN_TTL
 		);
 
@@ -115,12 +124,18 @@ export class TokensService {
 				throw new UnauthorizedException('ERROR_INVALID_REFRESH_TOKEN');
 			}
 
-			let storedData: { userId: string; deviceId: string; fingerprint: string } | null;
+			let storedData: {
+				userId: string;
+				deviceId: string;
+				fingerprint: string;
+				firstIssuedAt?: number;
+			} | null;
 			try {
 				storedData = await this.cacheService.getReliable<{
 					userId: string;
 					deviceId: string;
 					fingerprint: string;
+					firstIssuedAt?: number;
 				}>(`refresh_token:${decoded.tokenId}`);
 			} catch {
 				// Redis indisponible : ne pas confondre avec une révocation. Sinon
@@ -138,9 +153,27 @@ export class TokensService {
 				throw new UnauthorizedException('ERROR_DEVICE_FINGERPRINT_MISMATCH');
 			}
 
+			// cap absolu : on prefere la valeur du claim signe (immuable cote client)
+			// puis fallback sur le stored data ; backward compat = sessions sans
+			// firstIssuedAt sont seedees a Date.now() au prochain refresh (pas hard-fail).
+			const sessionFirstIssuedAt: number =
+				typeof decoded.firstIssuedAt === 'number'
+					? decoded.firstIssuedAt
+					: (storedData.firstIssuedAt ?? Date.now());
+
+			if (Date.now() - sessionFirstIssuedAt > this.ABSOLUTE_SESSION_CAP_MS) {
+				await this.revokeRefreshToken(decoded.tokenId);
+				throw new UnauthorizedException('ERROR_SESSION_EXPIRED_ABSOLUTE');
+			}
+
 			await this.revokeRefreshToken(decoded.tokenId);
 
-			return this.generateTokenPair(storedData.userId, storedData.deviceId, fingerprint);
+			return this.generateTokenPair(
+				storedData.userId,
+				storedData.deviceId,
+				fingerprint,
+				sessionFirstIssuedAt
+			);
 		} catch (error) {
 			if (error instanceof UnauthorizedException) {
 				throw error;


### PR DESCRIPTION
## Summary
- Cap absolu de 90 jours sur la duree d'une session, mesuree depuis le login initial (firstIssuedAt) et propagee a chaque refresh.
- Avant : un refresh token vole sur compte actif restait valide indefiniment via refresh roulants. Sessions zombies en Redis.
- Apres : passe le cap 90j -> revocation + 401 ERROR_SESSION_EXPIRED_ABSOLUTE -> re-auth obligatoire.

## Backward compat
- Sessions deja en cours sans firstIssuedAt : seedees a Date.now() au prochain refresh, pas de hard-fail.
- Au prochain refresh, le claim signe contiendra firstIssuedAt et le compteur 90j demarre.

## Test plan
- [x] Unit : firstIssuedAt propage du vieux refresh vers la nouvelle paire.
- [x] Unit : > 90j -> ERROR_SESSION_EXPIRED_ABSOLUTE + revocation.
- [x] Unit : sessions legacy sans firstIssuedAt -> seed Date.now() au prochain refresh.
- [x] npm test : 792 / 792 verts.

Closes WHISPR-1401