### PR TITLE
[WHISPR-1404] fix(security): strip /health public response

### DIFF
--- a/src/modules/health/health.controller.spec.ts
+++ b/src/modules/health/health.controller.spec.ts
@@ -53,9 +53,6 @@ describe('HealthController', () => {
 			const result = controller.alive();
 
 			expect(result.status).toBe('alive');
-			expect(result.timestamp).toBeDefined();
-			expect(result.uptime).toBeGreaterThanOrEqual(0);
-			expect(result.version).toBeDefined();
 		});
 
 		it('should not check database or cache', () => {
@@ -66,24 +63,37 @@ describe('HealthController', () => {
 			expect(mockCacheService.get).not.toHaveBeenCalled();
 		});
 
-		it('should not include services field in response', () => {
+		it('should not leak runtime metadata (uptime, version, timestamp)', () => {
 			const result = controller.alive();
 
-			expect(result).not.toHaveProperty('services');
+			expect(result).not.toHaveProperty('uptime');
+			expect(result).not.toHaveProperty('version');
+			expect(result).not.toHaveProperty('timestamp');
 		});
 	});
 
 	describe('check (general health)', () => {
-		it('should return 200 when all services are healthy', async () => {
+		it('should return only { status: "ok" } when all services are healthy', async () => {
 			mockDataSource.query.mockResolvedValue([{ '?column?': 1 }]);
 			mockCacheService.set.mockResolvedValue(undefined);
 			mockCacheService.get.mockResolvedValue('ok');
 
 			const result = await controller.check();
 
-			expect(result.status).toBe('ok');
-			expect(result.services.database).toBe('healthy');
-			expect(result.services.cache).toBe('healthy');
+			expect(result).toEqual({ status: 'ok' });
+		});
+
+		it('should not leak runtime metadata (uptime, memory, version)', async () => {
+			mockDataSource.query.mockResolvedValue([{ '?column?': 1 }]);
+			mockCacheService.set.mockResolvedValue(undefined);
+			mockCacheService.get.mockResolvedValue('ok');
+
+			const result = (await controller.check()) as Record<string, unknown>;
+
+			expect(result).not.toHaveProperty('uptime');
+			expect(result).not.toHaveProperty('memory');
+			expect(result).not.toHaveProperty('version');
+			expect(result).not.toHaveProperty('services');
 		});
 
 		it('should throw ServiceUnavailableException when database is down', async () => {

--- a/src/modules/health/health.controller.swagger.ts
+++ b/src/modules/health/health.controller.swagger.ts
@@ -5,7 +5,7 @@ export const ApiHealthCheckEndpoint = () =>
 	applyDecorators(
 		ApiOperation({
 			summary: 'Check service health',
-			description: 'Returns the health status of the service and its dependencies (database and cache)',
+			description: 'Returns a minimal public health status. No runtime metadata is exposed.',
 		}),
 		ApiResponse({ status: 200, description: 'Health check completed successfully' }),
 		ApiResponse({ status: 503, description: 'One or more services are unhealthy' })

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -29,53 +29,34 @@ export class HealthController {
 
 	@Get()
 	@ApiHealthCheckEndpoint()
-	async check() {
-		this.logger.debug('Health check started');
+	async check(): Promise<{ status: 'ok' }> {
+		// Reponse publique minimale - pas d'uptime/memory/version (info disclosure).
+		// Le controle effectif des dependances reste sur /health/ready (probe k8s).
+		let healthy = true;
 
-		const health = {
-			status: 'ok',
-			timestamp: new Date().toISOString(),
-			uptime: process.uptime(),
-			memory: process.memoryUsage(),
-			version: process.env.npm_package_version || '1.0.0',
-			services: {
-				database: 'unknown',
-				cache: 'unknown',
-			},
-		};
-
-		// Check database connection
 		try {
-			this.logger.debug('Checking database connection');
 			await this.dataSource.query('SELECT 1');
-			health.services.database = 'healthy';
-			this.logger.debug('Database check passed');
 		} catch (error) {
 			if (process.env.NODE_ENV !== 'test') {
 				this.logger.error('Database check failed:', error.message);
 			}
-			health.services.database = 'unhealthy';
-			health.status = 'error';
+			healthy = false;
 		}
 
-		// Check cache connection
 		try {
 			await this.checkCacheHealth();
-			health.services.cache = 'healthy';
 		} catch (error) {
 			if (process.env.NODE_ENV !== 'test') {
 				this.logger.error('Cache check failed:', error.message);
 			}
-			health.services.cache = 'unhealthy';
-			health.status = 'error';
+			healthy = false;
 		}
 
-		if (health.status !== 'ok') {
-			throw new ServiceUnavailableException(health);
+		if (!healthy) {
+			throw new ServiceUnavailableException({ status: 'error' });
 		}
 
-		this.logger.debug('Health check completed:', health);
-		return health;
+		return { status: 'ok' };
 	}
 
 	@Get('ready')
@@ -123,12 +104,8 @@ export class HealthController {
 
 	@Get('live')
 	@ApiLivenessEndpoint()
-	alive() {
-		return {
-			status: 'alive',
-			timestamp: new Date().toISOString(),
-			uptime: process.uptime(),
-			version: process.env.npm_package_version || '1.0.0',
-		};
+	alive(): { status: 'alive' } {
+		// Liveness probe k8s - reponse minimale pour eviter info disclosure (version/uptime).
+		return { status: 'alive' };
 	}
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -101,26 +101,20 @@ describe('AuthController (e2e)', () => {
 	});
 
 	describe('GET /auth/v1/health', () => {
-		it('should return ok with healthy services when database and cache are up', async () => {
+		it('should return only { status: "ok" } when database and cache are up', async () => {
 			const response = await request(app.getHttpServer()).get('/auth/v1/health').expect(200);
 
-			expect(response.body.status).toBe('ok');
-			expect(response.body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-			expect(Date.parse(response.body.timestamp)).not.toBeNaN();
-			expect(Number.isFinite(response.body.uptime)).toBe(true);
-			expect(response.body.uptime).toBeGreaterThanOrEqual(0);
-			expect(response.body.version).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/);
-			expect(response.body.memory).toEqual(
-				expect.objectContaining({
-					rss: expect.any(Number),
-					heapTotal: expect.any(Number),
-					heapUsed: expect.any(Number),
-				})
-			);
-			expect(response.body.services).toEqual({
-				database: 'healthy',
-				cache: 'healthy',
-			});
+			expect(response.body).toEqual({ status: 'ok' });
+		});
+
+		it('should not leak runtime metadata (uptime, memory, version, services)', async () => {
+			const response = await request(app.getHttpServer()).get('/auth/v1/health').expect(200);
+
+			expect(response.body).not.toHaveProperty('uptime');
+			expect(response.body).not.toHaveProperty('memory');
+			expect(response.body).not.toHaveProperty('version');
+			expect(response.body).not.toHaveProperty('timestamp');
+			expect(response.body).not.toHaveProperty('services');
 		});
 
 		it('should return 503 when database is unhealthy', async () => {
@@ -129,21 +123,19 @@ describe('AuthController (e2e)', () => {
 			const response = await request(app.getHttpServer()).get('/auth/v1/health').expect(503);
 
 			expect(response.body.status).toBe('error');
-			expect(response.body.services.database).toBe('unhealthy');
+			// Pas de fuite des details services dans la reponse publique d'erreur.
+			expect(response.body).not.toHaveProperty('services');
 		});
 	});
 
 	describe('GET /auth/v1/health/live', () => {
-		it('should return alive status without checking dependencies', async () => {
+		it('should return only { status: "alive" } without checking dependencies or leaking metadata', async () => {
 			const response = await request(app.getHttpServer()).get('/auth/v1/health/live').expect(200);
 
-			expect(response.body.status).toBe('alive');
-			expect(response.body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-			expect(Date.parse(response.body.timestamp)).not.toBeNaN();
-			expect(Number.isFinite(response.body.uptime)).toBe(true);
-			expect(response.body.uptime).toBeGreaterThanOrEqual(0);
-			expect(response.body.version).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/);
-			expect(response.body).not.toHaveProperty('services');
+			expect(response.body).toEqual({ status: 'alive' });
+			expect(response.body).not.toHaveProperty('uptime');
+			expect(response.body).not.toHaveProperty('version');
+			expect(response.body).not.toHaveProperty('timestamp');
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- `GET /health` retourne desormais `{ status: 'ok' }` minimal - plus de fuite d'`uptime`, `memory`, `version`, `timestamp` ni du detail des dependances.
- `GET /health/live` retourne uniquement `{ status: 'alive' }` (probe k8s lightweight, plus d'`uptime`/`version`).
- Les controles DB + cache continuent de tourner cote serveur sur `/health` ; un 503 est leve si l'un d'eux est KO, mais sans exposer la liste des services dans la reponse.
- `/health/ready` (probe readiness) reste inchange car deja sans fuite de runtime metadata.

## Pourquoi
Information disclosure : exposer la version + le memory layout du process facilite le ciblage d'exploits (CVE par version, fingerprinting). Pour une route accessible sur le port 3001 sans auth, c'est une mauvaise hygiene.

## Test plan
- [x] Unit tests verts (`npx jest --no-coverage` -> 793 passed)
- [x] Lint + prettier clean
- [x] Specs mis a jour pour asserer la reponse minimale et l'absence de leaks
- [x] e2e `app.e2e-spec.ts` adapte (assertions sur `not.toHaveProperty('uptime' / 'memory' / 'version' / 'services')`)

Closes WHISPR-1404