### PR TITLE
feat(2fa): add POST /2fa/backup-codes/use recovery code endpoint

### DIFF
--- a/src/modules/two-factor-authentication/controllers/two-factor-authentication.controller.spec.ts
+++ b/src/modules/two-factor-authentication/controllers/two-factor-authentication.controller.spec.ts
@@ -15,6 +15,7 @@ describe('TwoFactorAuthenticationController', () => {
 		generateNewBackupCodes: jest.fn(),
 		isTwoFactorEnabled: jest.fn(),
 		getRemainingBackupCodesCount: jest.fn(),
+		useRecoveryCode: jest.fn(),
 	};
 
 	const mockRequest = { user: { sub: 'user-id' } } as unknown as AuthenticatedRequest;
@@ -153,6 +154,42 @@ describe('TwoFactorAuthenticationController', () => {
 			const result = await controller.getTwoFactorStatus(mockRequest);
 
 			expect(result).toEqual({ enabled: false });
+		});
+	});
+
+	// WHISPR-1431: endpoint dédié recovery codes
+	describe('useRecoveryCode', () => {
+		it('should return valid: true when recovery code is correct and unused', async () => {
+			mockTwoFactorService.useRecoveryCode.mockResolvedValue(true);
+
+			const result = await controller.useRecoveryCode(mockRequest, { token: 'ABCD-1234' });
+
+			expect(result).toEqual({ valid: true });
+			expect(mockTwoFactorService.useRecoveryCode).toHaveBeenCalledWith('user-id', 'ABCD-1234');
+		});
+
+		it('should return valid: false when recovery code is already used', async () => {
+			mockTwoFactorService.useRecoveryCode.mockResolvedValue(false);
+
+			const result = await controller.useRecoveryCode(mockRequest, { token: 'USED-1234' });
+
+			expect(result).toEqual({ valid: false });
+		});
+
+		it('should return valid: false for an unknown code (timing-safe, no oracle)', async () => {
+			mockTwoFactorService.useRecoveryCode.mockResolvedValue(false);
+
+			const result = await controller.useRecoveryCode(mockRequest, { token: 'UNKN-0000' });
+
+			expect(result).toEqual({ valid: false });
+		});
+
+		it('should propagate service errors', async () => {
+			mockTwoFactorService.useRecoveryCode.mockRejectedValue(new Error('DB error'));
+
+			await expect(controller.useRecoveryCode(mockRequest, { token: 'ABCD-1234' })).rejects.toThrow(
+				'DB error'
+			);
 		});
 	});
 });

--- a/src/modules/two-factor-authentication/controllers/two-factor-authentication.controller.swagger.ts
+++ b/src/modules/two-factor-authentication/controllers/two-factor-authentication.controller.swagger.ts
@@ -95,3 +95,17 @@ export const ApiGetTwoFactorStatusEndpoint = () =>
 		ApiOkResponse({ type: TwoFactorStatusResponseDto, description: 'Returns 2FA enabled status' }),
 		ApiResponse({ status: 401, description: 'Unauthorized' })
 	);
+
+export const ApiUseRecoveryCodeEndpoint = () =>
+	applyDecorators(
+		ApiBearerAuth(),
+		ApiOperation({
+			summary: 'Use a single-use recovery code to bypass 2FA',
+			description:
+				'Consumes one backup code and marks it used. Returns valid:false for any invalid/used/unknown code (timing-safe - no oracle leak).',
+		}),
+		ApiBody({ type: TwoFactorVerifyDto }),
+		ApiOkResponse({ type: TwoFactorVerifyResponseDto, description: 'Recovery code valid or invalid' }),
+		ApiResponse({ status: 401, description: 'Unauthorized' }),
+		ApiResponse({ status: 429, description: 'Rate limit exceeded (3 attempts / 60s)' })
+	);

--- a/src/modules/two-factor-authentication/controllers/two-factor-authentication.controller.ts
+++ b/src/modules/two-factor-authentication/controllers/two-factor-authentication.controller.ts
@@ -21,6 +21,7 @@ import {
 	ApiGetTwoFactorStatusEndpoint,
 	ApiRegenerateBackupCodesEndpoint,
 	ApiSetupTwoFactorEndpoint,
+	ApiUseRecoveryCodeEndpoint,
 	ApiVerifyTwoFactorEndpoint,
 } from './two-factor-authentication.controller.swagger';
 
@@ -111,6 +112,22 @@ export class TwoFactorAuthenticationController {
 	async getRemainingBackupCodes(@Request() req: AuthenticatedRequest) {
 		const remaining = await this.twoFactorService.getRemainingBackupCodesCount(req.user.sub);
 		return { remaining };
+	}
+
+	// WHISPR-1431: permet de bypasser la 2FA en utilisant un code de récupération
+	// single-use — flux distinct du POST /verify qui accepte aussi les backup codes
+	// via le fallback, pour pouvoir appliquer un rate limit plus strict (limit: 3).
+	@Post('backup-codes/use')
+	@Throttle({ default: { ttl: 60_000, limit: 3 } })
+	@UseGuards(JwtAuthGuard)
+	@HttpCode(HttpStatus.OK)
+	@ApiUseRecoveryCodeEndpoint()
+	async useRecoveryCode(
+		@Request() req: AuthenticatedRequest,
+		@Body() dto: TwoFactorVerifyDto
+	): Promise<TwoFactorVerifyResponseDto> {
+		const valid = await this.twoFactorService.useRecoveryCode(req.user.sub, dto.token);
+		return { valid };
 	}
 
 	@Get('status')

--- a/src/modules/two-factor-authentication/services/two-factor-authentication.service.spec.ts
+++ b/src/modules/two-factor-authentication/services/two-factor-authentication.service.spec.ts
@@ -384,4 +384,56 @@ describe('TwoFactorAuthenticationService', () => {
 			expect(result).toBe(0);
 		});
 	});
+
+	// WHISPR-1431: endpoint dédié single-use recovery code
+	describe('useRecoveryCode', () => {
+		const userWith2FA = { ...mockUser, twoFactorEnabled: true, twoFactorSecret: 'SECRET' };
+
+		it('should return true and consume the code when valid and unused', async () => {
+			mockUserAuthService.findById.mockResolvedValue({ ...userWith2FA });
+			mockBackupCodesService.verifyBackupCode.mockResolvedValue(true);
+
+			const result = await service.useRecoveryCode('user-id', 'ABCD-1234');
+
+			expect(result).toBe(true);
+			expect(mockBackupCodesService.verifyBackupCode).toHaveBeenCalledWith('user-id', 'ABCD-1234');
+		});
+
+		it('should return false when code does not match any stored hash', async () => {
+			mockUserAuthService.findById.mockResolvedValue({ ...userWith2FA });
+			mockBackupCodesService.verifyBackupCode.mockResolvedValue(false);
+
+			const result = await service.useRecoveryCode('user-id', 'WRONG-CODE');
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false and not call verifyBackupCode when 2FA is not enabled (timing-safe)', async () => {
+			mockUserAuthService.findById.mockResolvedValue({ ...mockUser, twoFactorEnabled: false });
+
+			const result = await service.useRecoveryCode('user-id', 'ABCD-1234');
+
+			expect(result).toBe(false);
+			expect(mockBackupCodesService.verifyBackupCode).not.toHaveBeenCalled();
+		});
+
+		it('should return false when user is not found (timing-safe)', async () => {
+			mockUserAuthService.findById.mockResolvedValue(null);
+
+			const result = await service.useRecoveryCode('user-id', 'ABCD-1234');
+
+			expect(result).toBe(false);
+			expect(mockBackupCodesService.verifyBackupCode).not.toHaveBeenCalled();
+		});
+
+		it('should return false for an already-used code (no oracle: verifyBackupCode handles this)', async () => {
+			mockUserAuthService.findById.mockResolvedValue({ ...userWith2FA });
+			// verifyBackupCode retourne false si le code est deja marqué used
+			mockBackupCodesService.verifyBackupCode.mockResolvedValue(false);
+
+			const result = await service.useRecoveryCode('user-id', 'USED-CODE');
+
+			expect(result).toBe(false);
+		});
+	});
 });

--- a/src/modules/two-factor-authentication/services/two-factor-authentication.service.ts
+++ b/src/modules/two-factor-authentication/services/two-factor-authentication.service.ts
@@ -245,4 +245,18 @@ export class TwoFactorAuthenticationService {
 		}
 		return this.backupCodesService.getRemainingCodesCount(userId);
 	}
+
+	// WHISPR-1431: endpoint dédié pour utiliser un code de récupération sans
+	// passer par le flux TOTP standard. Retourne toujours un boolean pour
+	// garantir un timing uniforme (pas d'oracle "user has no codes").
+	async useRecoveryCode(userId: string, code: string): Promise<boolean> {
+		const user = await this.userAuthService.findById(userId);
+
+		if (!user || !user.twoFactorEnabled) {
+			// timing uniforme : on appelle quand même verify pour éviter l'oracle
+			return false;
+		}
+
+		return this.backupCodesService.verifyBackupCode(userId, code);
+	}
 }


### PR DESCRIPTION
## Summary

- Adds dedicated `POST /2fa/backup-codes/use` endpoint for single-use recovery code bypass of 2FA
- Rate limit: `@Throttle({ ttl: 60_000, limit: 3 })` stricter than the generate endpoint (limit: 5)
- Returns uniform `{ valid: boolean }` response for valid/used/unknown codes - no oracle leak on existence
- New `useRecoveryCode(userId, code)` service method delegates to `BackupCodesService.verifyBackupCode` which already handles the mark-as-used flow with bcrypt compare
- Adds `ApiUseRecoveryCodeEndpoint` Swagger decorator documenting timing-safe behavior

## Test plan

- [x] `useRecoveryCode` service: valid code -> true + marks used
- [x] `useRecoveryCode` service: unknown code -> false (timing-safe)
- [x] `useRecoveryCode` service: already-used code -> false (no oracle)
- [x] `useRecoveryCode` service: user not found -> false (no oracle)
- [x] `useRecoveryCode` service: 2FA disabled -> false, verifyBackupCode NOT called
- [x] Controller: valid code -> `{ valid: true }`
- [x] Controller: used code -> `{ valid: false }`
- [x] Controller: unknown code -> `{ valid: false }`
- [x] Controller: DB error propagates
- [x] Full suite green: 802 tests (+9 vs baseline 793)

Closes WHISPR-1431