### PR TITLE
fix(devices): auto-prune oldest device on limit + UA-based web device name

### DIFF
--- a/src/modules/devices/repositories/device.repository.spec.ts
+++ b/src/modules/devices/repositories/device.repository.spec.ts
@@ -139,4 +139,27 @@ describe('DeviceRepository', () => {
 			expect(result).toBeNull();
 		});
 	});
+
+	describe('findOldestVerifiedByUserId', () => {
+		it('should return the oldest verified device ordered by createdAt ASC', async () => {
+			const device = { id: 'oldest-device', userId: 'user-id', isVerified: true } as Device;
+			(repository.findOne as jest.Mock).mockResolvedValue(device);
+
+			const result = await repository.findOldestVerifiedByUserId('user-id');
+
+			expect(result).toEqual(device);
+			expect(repository.findOne).toHaveBeenCalledWith({
+				where: { userId: 'user-id', isVerified: true },
+				order: { createdAt: 'ASC' },
+			});
+		});
+
+		it('should return null when user has no verified devices', async () => {
+			(repository.findOne as jest.Mock).mockResolvedValue(null);
+
+			const result = await repository.findOldestVerifiedByUserId('user-id');
+
+			expect(result).toBeNull();
+		});
+	});
 });

--- a/src/modules/devices/repositories/device.repository.ts
+++ b/src/modules/devices/repositories/device.repository.ts
@@ -63,4 +63,11 @@ export class DeviceRepository extends Repository<Device> {
 			where: { id: deviceId, userId },
 		});
 	}
+
+	async findOldestVerifiedByUserId(userId: string): Promise<Device | null> {
+		return this.findOne({
+			where: { userId, isVerified: true },
+			order: { createdAt: 'ASC' },
+		});
+	}
 }

--- a/src/modules/devices/services/device-registration/device-registration.service.spec.ts
+++ b/src/modules/devices/services/device-registration/device-registration.service.spec.ts
@@ -1,14 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException, Logger } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { DataSource, EntityManager, UpdateResult } from 'typeorm';
 import { DeviceRegistrationService } from './device-registration.service';
 import { DeviceRepository } from '../../repositories/device.repository';
+import { TokensService } from '../../../tokens/services/tokens.service';
 import { Device } from '../../entities/device.entity';
 import { DeviceRegistrationData } from '../../types/device-registration-data.interface';
 
 describe('DeviceRegistrationService', () => {
 	let service: DeviceRegistrationService;
 	let deviceRepository: jest.Mocked<DeviceRepository>;
+	let tokensService: jest.Mocked<TokensService>;
 	let dataSource: jest.Mocked<DataSource>;
 	let entityManager: jest.Mocked<EntityManager>;
 	let transactionRepository: jest.Mocked<DeviceRepository>;
@@ -55,8 +57,10 @@ describe('DeviceRegistrationService', () => {
 		const mockDeviceRepository = {
 			findByUserAndFingerprint: jest.fn(),
 			countVerifiedDevices: jest.fn(),
+			findOldestVerifiedByUserId: jest.fn(),
 			create: jest.fn(),
 			save: jest.fn(),
+			remove: jest.fn(),
 			update: jest.fn(),
 		};
 
@@ -75,12 +79,20 @@ describe('DeviceRegistrationService', () => {
 			transaction: jest.fn(),
 		} as any;
 
+		const mockTokensService = {
+			revokeAllTokensForDevice: jest.fn().mockResolvedValue(undefined),
+		};
+
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [
 				DeviceRegistrationService,
 				{
 					provide: DeviceRepository,
 					useValue: mockDeviceRepository,
+				},
+				{
+					provide: TokensService,
+					useValue: mockTokensService,
 				},
 				{
 					provide: DataSource,
@@ -91,6 +103,7 @@ describe('DeviceRegistrationService', () => {
 
 		service = module.get<DeviceRegistrationService>(DeviceRegistrationService);
 		deviceRepository = module.get(DeviceRepository);
+		tokensService = module.get(TokensService);
 
 		// Mock logger
 		jest.spyOn(Logger.prototype, 'log').mockImplementation();
@@ -282,36 +295,62 @@ describe('DeviceRegistrationService', () => {
 			});
 		});
 
-		describe('Device limit enforcement', () => {
-			it('should throw ForbiddenException when device limit is reached', async () => {
+		describe('Device limit enforcement with auto-prune', () => {
+			it('should prune the oldest device and create a new one when limit is reached', async () => {
 				const registrationData = createRegistrationDataFixture();
+				const oldestDevice = createDeviceFixture({
+					id: 'oldest-device-id',
+					deviceName: 'Old iPhone',
+					createdAt: new Date('2025-01-01T00:00:00Z'),
+				});
+				const newDevice = createDeviceFixture({ id: 'new-device-id' });
 
 				transactionRepository.findByUserAndFingerprint.mockResolvedValue(null);
 				transactionRepository.countVerifiedDevices.mockResolvedValue(10);
+				transactionRepository.findOldestVerifiedByUserId.mockResolvedValue(oldestDevice);
+				transactionRepository.remove.mockResolvedValue(oldestDevice);
+				transactionRepository.create.mockReturnValue(newDevice);
+				transactionRepository.save.mockResolvedValue(newDevice);
 
 				(dataSource.transaction as jest.Mock).mockImplementation(async (callback) => {
 					return callback(entityManager);
 				});
 
-				await expect(service.registerDevice(registrationData)).rejects.toThrow(ForbiddenException);
+				const result = await service.registerDevice(registrationData);
+
+				expect(transactionRepository.remove).toHaveBeenCalledWith(oldestDevice);
+				expect(tokensService.revokeAllTokensForDevice).toHaveBeenCalledWith('oldest-device-id');
+				expect(transactionRepository.create).toHaveBeenCalled();
+				expect(result.id).toBe('new-device-id');
 			});
 
-			it('should throw ForbiddenException with descriptive message at limit', async () => {
+			it('devrait logger un warn avec userId, oldDeviceId et oldDeviceName lors du prune', async () => {
 				const registrationData = createRegistrationDataFixture();
+				const oldestDevice = createDeviceFixture({
+					id: 'pruned-id',
+					deviceName: 'Vieux Device',
+				});
+				const newDevice = createDeviceFixture();
 
 				transactionRepository.findByUserAndFingerprint.mockResolvedValue(null);
 				transactionRepository.countVerifiedDevices.mockResolvedValue(10);
+				transactionRepository.findOldestVerifiedByUserId.mockResolvedValue(oldestDevice);
+				transactionRepository.remove.mockResolvedValue(oldestDevice);
+				transactionRepository.create.mockReturnValue(newDevice);
+				transactionRepository.save.mockResolvedValue(newDevice);
 
 				(dataSource.transaction as jest.Mock).mockImplementation(async (callback) => {
 					return callback(entityManager);
 				});
 
-				await expect(service.registerDevice(registrationData)).rejects.toThrow(
-					'Device limit reached. Maximum 10 devices allowed per user.'
-				);
+				await service.registerDevice(registrationData);
+
+				expect(Logger.prototype.warn).toHaveBeenCalledWith(expect.stringContaining('device pruned'));
+				expect(Logger.prototype.warn).toHaveBeenCalledWith(expect.stringContaining('pruned-id'));
+				expect(Logger.prototype.warn).toHaveBeenCalledWith(expect.stringContaining('Vieux Device'));
 			});
 
-			it('should allow registration when below device limit', async () => {
+			it('should allow registration when below device limit without pruning', async () => {
 				const registrationData = createRegistrationDataFixture();
 				const expectedDevice = createDeviceFixture();
 
@@ -326,6 +365,8 @@ describe('DeviceRegistrationService', () => {
 
 				const result = await service.registerDevice(registrationData);
 
+				expect(transactionRepository.findOldestVerifiedByUserId).not.toHaveBeenCalled();
+				expect(transactionRepository.remove).not.toHaveBeenCalled();
 				expect(result).toBeDefined();
 				expect(transactionRepository.create).toHaveBeenCalled();
 			});
@@ -344,6 +385,82 @@ describe('DeviceRegistrationService', () => {
 				await service.registerDevice(registrationData);
 
 				expect(transactionRepository.countVerifiedDevices).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('UA-based device naming', () => {
+			it('utilise le deviceName fourni par le client si non vide', async () => {
+				const registrationData = createRegistrationDataFixture({
+					deviceName: 'Mon iPhone',
+					userAgent:
+						'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124.0.0.0 Safari/537.36',
+				});
+				const expectedDevice = createDeviceFixture({ deviceName: 'Mon iPhone' });
+
+				transactionRepository.findByUserAndFingerprint.mockResolvedValue(null);
+				transactionRepository.countVerifiedDevices.mockResolvedValue(0);
+				transactionRepository.create.mockReturnValue(expectedDevice);
+				transactionRepository.save.mockResolvedValue(expectedDevice);
+
+				(dataSource.transaction as jest.Mock).mockImplementation(async (callback) => {
+					return callback(entityManager);
+				});
+
+				await service.registerDevice(registrationData);
+
+				expect(transactionRepository.create).toHaveBeenCalledWith(
+					expect.objectContaining({ deviceName: 'Mon iPhone' })
+				);
+			});
+
+			it('construit un nom depuis le User-Agent Chrome/Windows quand deviceName est vide', async () => {
+				const chromeUa =
+					'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+				const registrationData = createRegistrationDataFixture({
+					deviceName: '',
+					userAgent: chromeUa,
+				});
+				const expectedDevice = createDeviceFixture({
+					deviceName: 'Web (Chrome 124 / Windows 10/11)',
+				});
+
+				transactionRepository.findByUserAndFingerprint.mockResolvedValue(null);
+				transactionRepository.countVerifiedDevices.mockResolvedValue(0);
+				transactionRepository.create.mockReturnValue(expectedDevice);
+				transactionRepository.save.mockResolvedValue(expectedDevice);
+
+				(dataSource.transaction as jest.Mock).mockImplementation(async (callback) => {
+					return callback(entityManager);
+				});
+
+				await service.registerDevice(registrationData);
+
+				expect(transactionRepository.create).toHaveBeenCalledWith(
+					expect.objectContaining({ deviceName: 'Web (Chrome 124 / Windows 10/11)' })
+				);
+			});
+
+			it('retourne "Web (Inconnu)" quand deviceName est vide et userAgent absent', async () => {
+				const registrationData = createRegistrationDataFixture({
+					deviceName: '',
+					userAgent: undefined,
+				});
+				const expectedDevice = createDeviceFixture({ deviceName: 'Web (Inconnu)' });
+
+				transactionRepository.findByUserAndFingerprint.mockResolvedValue(null);
+				transactionRepository.countVerifiedDevices.mockResolvedValue(0);
+				transactionRepository.create.mockReturnValue(expectedDevice);
+				transactionRepository.save.mockResolvedValue(expectedDevice);
+
+				(dataSource.transaction as jest.Mock).mockImplementation(async (callback) => {
+					return callback(entityManager);
+				});
+
+				await service.registerDevice(registrationData);
+
+				expect(transactionRepository.create).toHaveBeenCalledWith(
+					expect.objectContaining({ deviceName: 'Web (Inconnu)' })
+				);
 			});
 		});
 

--- a/src/modules/devices/services/device-registration/device-registration.service.spec.ts
+++ b/src/modules/devices/services/device-registration/device-registration.service.spec.ts
@@ -371,6 +371,28 @@ describe('DeviceRegistrationService', () => {
 				expect(transactionRepository.create).toHaveBeenCalled();
 			});
 
+			it('skips remove gracefully when no oldest device is found during prune', async () => {
+				const registrationData = createRegistrationDataFixture();
+				const newDevice = createDeviceFixture();
+
+				transactionRepository.findByUserAndFingerprint.mockResolvedValue(null);
+				transactionRepository.countVerifiedDevices.mockResolvedValue(10);
+				// Simule une situation de concurrence ou un repo vide
+				transactionRepository.findOldestVerifiedByUserId.mockResolvedValue(null);
+				transactionRepository.create.mockReturnValue(newDevice);
+				transactionRepository.save.mockResolvedValue(newDevice);
+
+				(dataSource.transaction as jest.Mock).mockImplementation(async (callback) => {
+					return callback(entityManager);
+				});
+
+				await service.registerDevice(registrationData);
+
+				expect(transactionRepository.remove).not.toHaveBeenCalled();
+				expect(tokensService.revokeAllTokensForDevice).not.toHaveBeenCalled();
+				expect(transactionRepository.create).toHaveBeenCalled();
+			});
+
 			it('should not check device count when updating an existing device', async () => {
 				const existingDevice = createDeviceFixture();
 				const registrationData = createRegistrationDataFixture();

--- a/src/modules/devices/services/device-registration/device-registration.service.ts
+++ b/src/modules/devices/services/device-registration/device-registration.service.ts
@@ -1,9 +1,11 @@
-import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { Device } from '../../entities/device.entity';
 import { DeviceRepository } from '../../repositories/device.repository';
 import { DeviceRegistrationData } from '../../types/device-registration-data.interface';
+import { TokensService } from '../../../tokens/services/tokens.service';
+import { buildWebDeviceName } from '../../utils/ua-device-name.util';
 
 const MAX_DEVICES_PER_USER = 10;
 
@@ -13,6 +15,7 @@ export class DeviceRegistrationService {
 
 	constructor(
 		private readonly deviceRepository: DeviceRepository,
+		private readonly tokensService: TokensService,
 		@InjectDataSource() private readonly dataSource: DataSource
 	) {}
 
@@ -34,14 +37,39 @@ export class DeviceRegistrationService {
 
 			const deviceCount = await transactionRepository.countVerifiedDevices(data.userId);
 			if (deviceCount >= MAX_DEVICES_PER_USER) {
-				throw new ForbiddenException(
-					`Device limit reached. Maximum ${MAX_DEVICES_PER_USER} devices allowed per user.`
-				);
+				await this.pruneOldestDevice(data.userId, transactionRepository);
 			}
 
+			const resolvedName = this.resolveDeviceName(data.deviceName, data.userAgent);
 			this.logger.log(`Registering new device for user: ${data.userId}`);
-			return this.createNewDevice(data, transactionRepository);
+			return this.createNewDevice({ ...data, deviceName: resolvedName }, transactionRepository);
 		});
+	}
+
+	/**
+	 * Supprime le device le plus ancien de l'utilisateur pour libérer une place.
+	 * Invalide également ses tokens (force logout sur ce device).
+	 */
+	private async pruneOldestDevice(userId: string, repository: DeviceRepository): Promise<void> {
+		const oldest = await repository.findOldestVerifiedByUserId(userId);
+		if (!oldest) return;
+
+		this.logger.warn(
+			`device pruned : userId=${userId}, oldDeviceId=${oldest.id}, oldDeviceName=${oldest.deviceName}`
+		);
+
+		// Invalider les tokens avant suppression pour forcer le logout
+		await this.tokensService.revokeAllTokensForDevice(oldest.id);
+		await repository.remove(oldest);
+	}
+
+	/**
+	 * Construit le nom du device.
+	 * Si le client n'en fournit pas (web PWA), on extrait Browser/OS depuis le User-Agent.
+	 */
+	private resolveDeviceName(providedName: string, userAgent?: string): string {
+		if (providedName && providedName.trim().length > 0) return providedName;
+		return buildWebDeviceName(userAgent);
 	}
 
 	private async updateExistingDevice(

--- a/src/modules/devices/types/device-registration-data.interface.ts
+++ b/src/modules/devices/types/device-registration-data.interface.ts
@@ -10,4 +10,6 @@ export interface DeviceRegistrationData {
 	fcmToken?: string;
 	apnsToken?: string;
 	deviceFingerprint: string;
+	/** User-Agent header du client, utilisé pour nommer les sessions web sans nom explicite */
+	userAgent?: string;
 }

--- a/src/modules/devices/utils/ua-device-name.util.spec.ts
+++ b/src/modules/devices/utils/ua-device-name.util.spec.ts
@@ -1,0 +1,74 @@
+import { buildWebDeviceName } from './ua-device-name.util';
+
+describe('buildWebDeviceName', () => {
+	describe('fallback sans User-Agent', () => {
+		it('retourne "Web (Inconnu)" si userAgent est undefined', () => {
+			expect(buildWebDeviceName(undefined)).toBe('Web (Inconnu)');
+		});
+
+		it('retourne "Web (Inconnu)" si userAgent est une chaine vide', () => {
+			expect(buildWebDeviceName('')).toBe('Web (Inconnu)');
+		});
+
+		it('retourne "Web (Inconnu)" si le UA ne correspond à aucune règle', () => {
+			expect(buildWebDeviceName('UnknownBot/1.0')).toBe('Web (Inconnu)');
+		});
+	});
+
+	describe('navigateurs desktop', () => {
+		it('parse Chrome sur Windows', () => {
+			const ua =
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+			expect(buildWebDeviceName(ua)).toBe('Web (Chrome 124 / Windows 10/11)');
+		});
+
+		it('parse Chrome sur macOS', () => {
+			const ua =
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+			expect(buildWebDeviceName(ua)).toBe('Web (Chrome 124 / macOS 10.15.7)');
+		});
+
+		it('parse Firefox sur Linux', () => {
+			const ua = 'Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0';
+			expect(buildWebDeviceName(ua)).toBe('Web (Firefox 125 / Linux)');
+		});
+
+		it('parse Safari sur macOS', () => {
+			const ua =
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15';
+			expect(buildWebDeviceName(ua)).toBe('Web (Safari 17 / macOS 14.4)');
+		});
+
+		it('parse Edge avant Chrome (tous deux present dans le UA)', () => {
+			const ua =
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0';
+			expect(buildWebDeviceName(ua)).toBe('Web (Edge 124 / Windows 10/11)');
+		});
+
+		it('parse Opera avant Chrome', () => {
+			const ua =
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 OPR/110.0.0.0';
+			expect(buildWebDeviceName(ua)).toBe('Web (Opera 110 / Windows 10/11)');
+		});
+	});
+
+	describe('navigateurs mobiles', () => {
+		it('parse Safari sur iOS', () => {
+			const ua =
+				'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1';
+			expect(buildWebDeviceName(ua)).toBe('Web (Safari 17 / iOS 17.4.1)');
+		});
+
+		it('parse Chrome sur Android', () => {
+			const ua =
+				'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.82 Mobile Safari/537.36';
+			expect(buildWebDeviceName(ua)).toBe('Web (Chrome 124 / Android 14)');
+		});
+
+		it('parse Samsung Browser sur Android', () => {
+			const ua =
+				'Mozilla/5.0 (Linux; Android 14; SM-S928B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/121.0.0.0 Mobile Safari/537.36';
+			expect(buildWebDeviceName(ua)).toBe('Web (Samsung Browser 25 / Android 14)');
+		});
+	});
+});

--- a/src/modules/devices/utils/ua-device-name.util.spec.ts
+++ b/src/modules/devices/utils/ua-device-name.util.spec.ts
@@ -71,4 +71,45 @@ describe('buildWebDeviceName', () => {
 			expect(buildWebDeviceName(ua)).toBe('Web (Samsung Browser 25 / Android 14)');
 		});
 	});
+
+	describe('branches de fallback (version absente)', () => {
+		it('retourne "iOS" sans numero si la version OS manque dans le UA iPhone', () => {
+			// UA synthétique sans "OS X_Y" -> extractOs retourne "iOS" sans version
+			expect(buildWebDeviceName('Mozilla/5.0 (iPhone; CPU like Mac OS X) Safari/604.1')).toBe(
+				'Web (iOS)'
+			);
+		});
+
+		it('retourne "Android" sans numero si la version Android manque', () => {
+			// UA synthétique sans "Android X.Y" -> extractOs retourne "Android" sans version
+			expect(buildWebDeviceName('Mozilla/5.0 (Linux; Android) Mobile Safari/537.36')).toBe(
+				'Web (Android)'
+			);
+		});
+
+		it('retourne "Windows X" pour une version NT non mappee', () => {
+			// NT 5.1 = XP, non dans la map -> utilise le numero brut
+			const ua = 'Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 Chrome/49.0.0.0 Safari/537.36';
+			expect(buildWebDeviceName(ua)).toBe('Web (Chrome 49 / Windows 5.1)');
+		});
+
+		it('retourne "Windows" seul si la version NT est absente', () => {
+			// Force label=null: "Windows NT" sans numero de version
+			const ua = 'Mozilla/5.0 (Windows NT) Chrome/120.0.0.0 Safari/537.36';
+			expect(buildWebDeviceName(ua)).toBe('Web (Chrome 120 / Windows)');
+		});
+
+		it('retourne "macOS" sans version si le UA Mac ne contient pas de version parsable', () => {
+			// UA synthétique sans "Mac OS X X_Y_Z"
+			const ua =
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/537.36 Chrome/100.0.0.0 Safari/537.36';
+			expect(buildWebDeviceName(ua)).toBe('Web (Chrome 100 / macOS)');
+		});
+
+		it('retourne navigateur seul si OS non identifie (navigateur connu sans OS reconnu)', () => {
+			// UA avec Firefox mais aucun OS reconnu
+			const ua = 'Mozilla/5.0 Firefox/125.0';
+			expect(buildWebDeviceName(ua)).toBe('Web (Firefox 125)');
+		});
+	});
 });

--- a/src/modules/devices/utils/ua-device-name.util.ts
+++ b/src/modules/devices/utils/ua-device-name.util.ts
@@ -1,0 +1,63 @@
+/**
+ * Extrait un nom lisible depuis un User-Agent HTTP.
+ * Format : "Web (Chrome 124 / Windows)" ou "Web (Inconnu)" si non parsable.
+ */
+export function buildWebDeviceName(userAgent?: string): string {
+	if (!userAgent) return 'Web (Inconnu)';
+
+	const browser = extractBrowser(userAgent);
+	const os = extractOs(userAgent);
+
+	if (!browser && !os) return 'Web (Inconnu)';
+	if (!os) return `Web (${browser})`;
+	if (!browser) return `Web (${os})`;
+	return `Web (${browser} / ${os})`;
+}
+
+function extractBrowser(ua: string): string | null {
+	// Ordre important : Edge et OPR avant Chrome car ils incluent "Chrome/" dans leur UA
+	const rules: [RegExp, string][] = [
+		[/Edg\/(\d+)/, 'Edge'],
+		[/OPR\/(\d+)/, 'Opera'],
+		[/Firefox\/(\d+)/, 'Firefox'],
+		[/SamsungBrowser\/(\d+)/, 'Samsung Browser'],
+		[/Chrome\/(\d+)/, 'Chrome'],
+		[/Version\/(\d+).*Safari/, 'Safari'],
+	];
+
+	for (const [re, name] of rules) {
+		const m = ua.match(re);
+		if (m) return `${name} ${m[1]}`;
+	}
+	return null;
+}
+
+function extractOs(ua: string): string | null {
+	if (/iPhone|iPad/.test(ua)) {
+		const m = ua.match(/OS ([\d_]+)/);
+		const ver = m ? m[1].replace(/_/g, '.') : null;
+		return ver ? `iOS ${ver}` : 'iOS';
+	}
+	if (/Android/.test(ua)) {
+		const m = ua.match(/Android ([\d.]+)/);
+		return m ? `Android ${m[1]}` : 'Android';
+	}
+	if (/Windows NT/.test(ua)) {
+		const m = ua.match(/Windows NT ([\d.]+)/);
+		const versions: Record<string, string> = {
+			'10.0': '10/11',
+			'6.3': '8.1',
+			'6.2': '8',
+			'6.1': '7',
+		};
+		const label = m ? (versions[m[1]] ?? m[1]) : null;
+		return label ? `Windows ${label}` : 'Windows';
+	}
+	if (/Mac OS X/.test(ua)) {
+		const m = ua.match(/Mac OS X ([\d_]+)/);
+		const ver = m ? m[1].replace(/_/g, '.') : null;
+		return ver ? `macOS ${ver}` : 'macOS';
+	}
+	if (/Linux/.test(ua)) return 'Linux';
+	return null;
+}

--- a/src/modules/devices/utils/ua-device-name.util.ts
+++ b/src/modules/devices/utils/ua-device-name.util.ts
@@ -1,6 +1,6 @@
 /**
  * Extrait un nom lisible depuis un User-Agent HTTP.
- * Format : "Web (Chrome 124 / Windows)" ou "Web (Inconnu)" si non parsable.
+ * Format : "Web (Chrome 124 / Windows 10/11)" ou "Web (Inconnu)" si non parsable.
  */
 export function buildWebDeviceName(userAgent?: string): string {
 	if (!userAgent) return 'Web (Inconnu)';
@@ -14,50 +14,62 @@ export function buildWebDeviceName(userAgent?: string): string {
 	return `Web (${browser} / ${os})`;
 }
 
-function extractBrowser(ua: string): string | null {
-	// Ordre important : Edge et OPR avant Chrome car ils incluent "Chrome/" dans leur UA
-	const rules: [RegExp, string][] = [
-		[/Edg\/(\d+)/, 'Edge'],
-		[/OPR\/(\d+)/, 'Opera'],
-		[/Firefox\/(\d+)/, 'Firefox'],
-		[/SamsungBrowser\/(\d+)/, 'Samsung Browser'],
-		[/Chrome\/(\d+)/, 'Chrome'],
-		[/Version\/(\d+).*Safari/, 'Safari'],
-	];
+// Ordre important : Edge et OPR avant Chrome car ils incluent "Chrome/" dans leur UA
+const BROWSER_RULES: [RegExp, string][] = [
+	[/Edg\/(\d+)/, 'Edge'],
+	[/OPR\/(\d+)/, 'Opera'],
+	[/Firefox\/(\d+)/, 'Firefox'],
+	[/SamsungBrowser\/(\d+)/, 'Samsung Browser'],
+	[/Chrome\/(\d+)/, 'Chrome'],
+	[/Version\/(\d+).*Safari/, 'Safari'],
+];
 
-	for (const [re, name] of rules) {
+function extractBrowser(ua: string): string | null {
+	for (const [re, name] of BROWSER_RULES) {
 		const m = ua.match(re);
 		if (m) return `${name} ${m[1]}`;
 	}
 	return null;
 }
 
+function detectIos(ua: string): string | null {
+	if (!/iPhone|iPad/.test(ua)) return null;
+	const m = ua.match(/OS ([\d_]+)/);
+	return m ? `iOS ${m[1].replace(/_/g, '.')}` : 'iOS';
+}
+
+function detectAndroid(ua: string): string | null {
+	if (!/Android/.test(ua)) return null;
+	const m = ua.match(/Android ([\d.]+)/);
+	return m ? `Android ${m[1]}` : 'Android';
+}
+
+const WINDOWS_NT_VERSIONS: Record<string, string> = {
+	'10.0': '10/11',
+	'6.3': '8.1',
+	'6.2': '8',
+	'6.1': '7',
+};
+
+function detectWindows(ua: string): string | null {
+	if (!/Windows NT/.test(ua)) return null;
+	const m = ua.match(/Windows NT ([\d.]+)/);
+	const label = m ? (WINDOWS_NT_VERSIONS[m[1]] ?? m[1]) : null;
+	return label ? `Windows ${label}` : 'Windows';
+}
+
+function detectMacos(ua: string): string | null {
+	if (!/Mac OS X/.test(ua)) return null;
+	const m = ua.match(/Mac OS X ([\d_]+)/);
+	return m ? `macOS ${m[1].replace(/_/g, '.')}` : 'macOS';
+}
+
 function extractOs(ua: string): string | null {
-	if (/iPhone|iPad/.test(ua)) {
-		const m = ua.match(/OS ([\d_]+)/);
-		const ver = m ? m[1].replace(/_/g, '.') : null;
-		return ver ? `iOS ${ver}` : 'iOS';
-	}
-	if (/Android/.test(ua)) {
-		const m = ua.match(/Android ([\d.]+)/);
-		return m ? `Android ${m[1]}` : 'Android';
-	}
-	if (/Windows NT/.test(ua)) {
-		const m = ua.match(/Windows NT ([\d.]+)/);
-		const versions: Record<string, string> = {
-			'10.0': '10/11',
-			'6.3': '8.1',
-			'6.2': '8',
-			'6.1': '7',
-		};
-		const label = m ? (versions[m[1]] ?? m[1]) : null;
-		return label ? `Windows ${label}` : 'Windows';
-	}
-	if (/Mac OS X/.test(ua)) {
-		const m = ua.match(/Mac OS X ([\d_]+)/);
-		const ver = m ? m[1].replace(/_/g, '.') : null;
-		return ver ? `macOS ${ver}` : 'macOS';
-	}
-	if (/Linux/.test(ua)) return 'Linux';
-	return null;
+	return (
+		detectIos(ua) ??
+		detectAndroid(ua) ??
+		detectWindows(ua) ??
+		detectMacos(ua) ??
+		(/Linux/.test(ua) ? 'Linux' : null)
+	);
 }

--- a/src/modules/phone-auth/services/phone-authentication.service.ts
+++ b/src/modules/phone-auth/services/phone-authentication.service.ts
@@ -68,10 +68,10 @@ export class PhoneAuthenticationService {
 		deviceInfo: DeviceInfo,
 		fingerprint: DeviceFingerprint
 	): Promise<string> {
-		if (deviceInfo.deviceName && deviceInfo.deviceType && deviceInfo.signalKeyBundle) {
+		if (deviceInfo.deviceType && deviceInfo.signalKeyBundle) {
 			const device = await this.deviceRegistrationService.registerDevice({
 				userId,
-				deviceName: deviceInfo.deviceName,
+				deviceName: deviceInfo.deviceName ?? '',
 				deviceType: deviceInfo.deviceType,
 				publicKey: deviceInfo.signalKeyBundle.identityKey,
 				ipAddress: fingerprint.ipAddress,
@@ -81,6 +81,7 @@ export class PhoneAuthenticationService {
 				fcmToken: deviceInfo.fcmToken,
 				apnsToken: deviceInfo.apnsToken,
 				deviceFingerprint: deviceInfo.deviceId ?? randomUUID(),
+				userAgent: fingerprint.userAgent,
 			});
 
 			await this.signalKeyStorageService.storeIdentityKey(


### PR DESCRIPTION
## Summary

- When a user hits the 10-device cap, the oldest verified device is silently pruned (delete + token revocation) instead of throwing 403, so web PWA logins never get blocked after 10 sessions.
- Web sessions without an explicit `deviceName` now receive a readable label built from the `User-Agent` header (e.g. `Web (Chrome 124 / Windows 10/11)`) instead of an empty string or `Unknown Device`.
- The `userAgent` field is forwarded from `DeviceFingerprint` through `DeviceRegistrationData` to the registration service.
- No schema changes required.

## Test plan

- [x] Unit: 10 devices exist + new login -> oldest device deleted, tokens revoked, total stays at 10
- [x] Unit: `Logger.warn` includes `userId`, `oldDeviceId`, `oldDeviceName` on prune
- [x] Unit: registration below limit does not trigger prune
- [x] Unit: update existing device skips count check entirely
- [x] Unit: `deviceName` provided by client is preserved as-is
- [x] Unit: empty `deviceName` + Chrome UA -> `Web (Chrome 124 / Windows 10/11)`
- [x] Unit: empty `deviceName` + no UA -> `Web (Inconnu)`
- [x] Unit: UA utility covers Chrome, Firefox, Safari, Edge, Opera, Samsung Browser on Windows/macOS/Linux/iOS/Android
- [x] Full suite: 817 tests pass (was ~792), no regression

Closes WHISPR-1443