### PR TITLE
fix(devices): remove backtracking regex for Safari UA parsing

### DIFF
--- a/src/modules/devices/utils/ua-device-name.util.ts
+++ b/src/modules/devices/utils/ua-device-name.util.ts
@@ -21,13 +21,20 @@ const BROWSER_RULES: [RegExp, string][] = [
 	[/Firefox\/(\d+)/, 'Firefox'],
 	[/SamsungBrowser\/(\d+)/, 'Samsung Browser'],
 	[/Chrome\/(\d+)/, 'Chrome'],
-	[/Version\/(\d+).*Safari/, 'Safari'],
 ];
+
+const SAFARI_VERSION = /Version\/(\d+)/;
 
 function extractBrowser(ua: string): string | null {
 	for (const [re, name] of BROWSER_RULES) {
 		const m = ua.match(re);
 		if (m) return `${name} ${m[1]}`;
+	}
+	// Safari : tester separement la presence du marker Safari et extraire Version/
+	// pour eviter un pattern regex avec backtracking (.*Safari).
+	if (ua.includes('Safari')) {
+		const m = ua.match(SAFARI_VERSION);
+		if (m) return `Safari ${m[1]}`;
 	}
 	return null;
 }


### PR DESCRIPTION
## Summary
- Replace `Version/(\d+).*Safari` (Sonar S5852 - super-linear regex backtracking risk) with a non-backtracking split: test Safari presence via `String.includes`, then extract version with a bounded `Version/(\d+)` pattern.
- Unblocks the deploy/preprod Sonar Quality Gate (currently failing on `new_security_hotspots_reviewed = 0%`), which in turn blocks the auth-service Docker build and ArgoCD rollout.
- Behavior preserved: same UA parsing semantics, same tests (18/18 green).

## Test plan
- [x] `npx jest src/modules/devices/utils/ua-device-name.util.spec.ts` - 18/18 green
- [x] `npx eslint` + `npx prettier --check` clean
- [x] CI Sonar Quality Gate green
- [x] Docker build + CD pipeline trigger

Closes WHISPR-1450