### PR TITLE
fix(signal): validate keyId as int32 to prevent Postgres numeric overflow

### DIFF
--- a/src/modules/phone-auth/dto/signal-keys.dto.ts
+++ b/src/modules/phone-auth/dto/signal-keys.dto.ts
@@ -1,10 +1,14 @@
-import { IsString, IsNumber, IsArray, ValidateNested } from 'class-validator';
+import { IsString, IsArray, ValidateNested, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
+const PG_INT32_MAX = 2147483647;
+
 export class PreKeyDto {
 	@ApiProperty({ description: 'Pre-key identifier', example: 1 })
-	@IsNumber()
+	@IsInt()
+	@Min(0)
+	@Max(PG_INT32_MAX)
 	keyId: number;
 
 	@ApiProperty({ description: 'Base64-encoded public key', example: 'BQ3Nc6BHnBm...' })
@@ -14,7 +18,9 @@ export class PreKeyDto {
 
 export class SignedPreKeyDto {
 	@ApiProperty({ description: 'Signed pre-key identifier', example: 1 })
-	@IsNumber()
+	@IsInt()
+	@Min(0)
+	@Max(PG_INT32_MAX)
 	keyId: number;
 
 	@ApiProperty({ description: 'Base64-encoded public key', example: 'BQ3Nc6BHnBm...' })

--- a/src/modules/signal/dto/signal-keys.dto.ts
+++ b/src/modules/signal/dto/signal-keys.dto.ts
@@ -1,10 +1,14 @@
-import { IsString, IsNumber, IsArray, ValidateNested } from 'class-validator';
+import { IsString, IsArray, ValidateNested, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
+const PG_INT32_MAX = 2147483647;
+
 export class PreKeyDto {
 	@ApiProperty({ description: 'One-time prekey identifier', example: 1 })
-	@IsNumber()
+	@IsInt()
+	@Min(0)
+	@Max(PG_INT32_MAX)
 	keyId: number;
 
 	@ApiProperty({ description: 'Base64-encoded public key', example: 'BZrt9...def456' })
@@ -14,7 +18,9 @@ export class PreKeyDto {
 
 export class SignedPreKeyDto {
 	@ApiProperty({ description: 'Signed prekey identifier', example: 1 })
-	@IsNumber()
+	@IsInt()
+	@Min(0)
+	@Max(PG_INT32_MAX)
 	keyId: number;
 
 	@ApiProperty({ description: 'Base64-encoded public key', example: 'BQXm8...abc123' })

--- a/test/login.e2e-spec.ts
+++ b/test/login.e2e-spec.ts
@@ -361,6 +361,44 @@ describe('Login Flow (e2e)', () => {
 			expect(response.body).toHaveProperty('message');
 		});
 
+		it('should return 400 when signedPreKey.keyId exceeds int32 max (9999999999)', async () => {
+			const response = await request(app.getHttpServer())
+				.post('/auth/v1/login')
+				.send({
+					verificationId: VERIFICATION_ID,
+					deviceName: 'Test Device',
+					deviceType: 'mobile',
+					signalKeyBundle: {
+						identityKey: 'base64-identity-key',
+						signedPreKey: { keyId: 9999999999, publicKey: 'base64-spk', signature: 'base64-sig' },
+						preKeys: [{ keyId: 1, publicKey: 'base64-pk1' }],
+					},
+				})
+				.set('User-Agent', 'Test Agent');
+
+			expect(response.status).toBe(400);
+			expect(response.body).toHaveProperty('message');
+		});
+
+		it('should return 400 when preKeys[].keyId exceeds int32 max (2147483648)', async () => {
+			const response = await request(app.getHttpServer())
+				.post('/auth/v1/login')
+				.send({
+					verificationId: VERIFICATION_ID,
+					deviceName: 'Test Device',
+					deviceType: 'mobile',
+					signalKeyBundle: {
+						identityKey: 'base64-identity-key',
+						signedPreKey: { keyId: 1, publicKey: 'base64-spk', signature: 'base64-sig' },
+						preKeys: [{ keyId: 2147483648, publicKey: 'base64-pk1' }],
+					},
+				})
+				.set('User-Agent', 'Test Agent');
+
+			expect(response.status).toBe(400);
+			expect(response.body).toHaveProperty('message');
+		});
+
 		it('should return 200 without User-Agent header', async () => {
 			const response = await request(app.getHttpServer())
 				.post('/auth/v1/login')


### PR DESCRIPTION
## Summary
- Add `@IsInt @Min(0) @Max(2147483647)` on `PreKeyDto.keyId` and `SignedPreKeyDto.keyId` in `phone-auth/dto/signal-keys.dto.ts` and `signal/dto/signal-keys.dto.ts`
- Prevents `POST /auth/v1/login` from crashing with Postgres error 22003 (numeric_value_out_of_range) when `keyId` exceeds int32 max
- Now returns 400 Bad Request with a validation message instead of 500

## Test plan
- [x] Unit tests: 826 passing
- [x] Lint: 0 errors
- [x] Two new e2e tests in `test/login.e2e-spec.ts` covering `signedPreKey.keyId` and `preKeys[].keyId` overflow (2147483648 / 9999999999)